### PR TITLE
Pairwise asymmetric inference

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 DynamicalSystems = "61744808-ddfa-5f27-97ff-6e42cc95d634"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Pkg
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
 CI && Pkg.activate(@__DIR__)
 CI && Pkg.instantiate()
-CI && (ENV["GKSwstype"] = "100")
+ENV["GKSwstype"] = "100" # allow local builds without output
 using DelayEmbeddings
 using TransferEntropy
 using Documenter
@@ -11,6 +11,7 @@ using DocumenterTools: Themes
 using CausalityTools
 using DynamicalSystems
 using HypothesisTests
+using Distributions
 
 # %% JuliaDynamics theme.
 # download the themes
@@ -40,6 +41,7 @@ PAGES = [
         "joint_distance_distribution.md",
         "s_measure.md",
         "cross_mapping.md",
+        "pairwise_asymmetric_inference.md"
     ],
     "Information/entropy based" => [
         "mutualinfo.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,6 +16,7 @@ properties of these delay reconstructions, to infer causal/dynamical relationshi
 time series, and embedding parameters (given as keyword arguments).
 
 - Cross mapping ([`crossmap`](@ref))
+- Pairwise asymmetric inference ([`pai`](@ref))
 - Joint distance distribution ([`jdd`](@ref))
 - S-measure ([`s_measure`](@ref))
 

--- a/docs/src/pairwise_asymmetric_inference.md
+++ b/docs/src/pairwise_asymmetric_inference.md
@@ -56,8 +56,8 @@ npts = 2000
 d, τ = 2, 1
 for (i, a) in enumerate(as)
     for (j, b) in enumerate(bs)
-        sys = nonlinear_sindriver(a = a, b = a, c = c)
-        orbit = trajectory(sys, npts, Ttr = 10000)
+        s = nonlinear_sindriver(a = a, b = a, c = c)
+        orbit = trajectory(s, npts, Ttr = 10000)
         X, Y = columns(orbit)
         # Use the segment bootstrap estimator, take the mean of 50 reps over segments of # length L = 200
         pai_xys[i, j] = pai(X, Y, d, τ, :segment, L = 200, nreps = 50) |> mean
@@ -66,7 +66,7 @@ for (i, a) in enumerate(as)
 end
 ```
 
-Now that we have computed the PAI in both directions, we define a measure of directionality as ``\\Delta = cor(y(t), \\tilde{y}(t) | M_{xy}) - cor(x(t), \\tilde{x}(t) | M_{yx})``, so that ``X`` drives ``Y``, then ``\\Delta < 0``.
+Now that we have computed the PAI in both directions, we define a measure of directionality as the difference between PAI in the ``X \\to Y`` direction and in the ``Y \\to X`` direction, so that if ``X`` drives ``Y``, then ``\\Delta < 0``.
 
 ```@example pai
 Δ = pai_xys .- pai_yxs

--- a/docs/src/pairwise_asymmetric_inference.md
+++ b/docs/src/pairwise_asymmetric_inference.md
@@ -66,7 +66,7 @@ for (i, a) in enumerate(as)
 end
 ```
 
-Now that we have computed the PAI in both directions, we define a measure of directionality as the difference between PAI in the ``X`` to ``Y`` direction and in the ``Y`` to ``X`` direction, so that if ``X`` drives ``Y``, then ``\\Delta < 0``.
+Now that we have computed the PAI in both directions, we define a measure of directionality as the difference between PAI in the ``X \to Y`` direction and in the ``Y \to X`` direction, so that if ``X`` drives ``Y``, then ``\Delta < 0``.
 
 ```@example pai_ex
 Δ = pai_xys .- pai_yxs

--- a/docs/src/pairwise_asymmetric_inference.md
+++ b/docs/src/pairwise_asymmetric_inference.md
@@ -1,0 +1,84 @@
+# Pairwise asymmetric inference
+
+```@docs
+pai
+```
+
+## Example: nonlinear system
+
+Let's try to reproduce figure 8 in McCracken & Weigel (2014)[^McCracken2014]. We'll start by defining the their example B (equations 6-7). This system consists of two
+variables ``X`` and ``Y``, where ``X`` drives ``Y``.
+
+```@example pai
+using CausalityTools, DynamicalSystems, Plots, StatsBase, Statistics, Distributions; gr()
+
+function eom_nonlinear_sindriver(dx, x, p, n)
+    a, b, c, t, Δt = (p...,)
+    x, y = x[1], x[2]
+    𝒩 = Normal(0, 1)
+    
+    dx[1] = sin(t)
+    dx[2] = a*x * (1 - b*x) + c*rand(𝒩)
+    p[end-1] += 1 # update t
+
+    return
+end
+
+function nonlinear_sindriver(;u₀ = rand(2), a = 1.0, b = 1.0, c = 2.0, Δt = 1)
+    DiscreteDynamicalSystem(eom_nonlinear_sindriver, u₀, [a, b, c, 0, Δt])
+end
+
+# Create a system of nonidentical logistic maps where coupling from variable x to variable y
+# is stronger than vice versa.
+sys = nonlinear_sindriver(a = 1.0, b = 1.0, c = 2.0)
+npts = 100
+orbit = trajectory(sys, npts, Ttr = 10000)
+x, y = columns(orbit);
+plot(xlabel = "Time step", ylabel = "Value")
+# Standardize and plot data
+plot!((x .- mean(x)) ./ std(x), label = "x")
+plot!((y .- mean(y)) ./ std(y), label = "y")
+savefig("pai_ts.svg") # hide
+```
+
+![](pai_ts.svg)
+
+Now, let's generate such time series for many different values of the parameters `a` and `b`, and compute PAI for fixed `p = 2.0`. This will replicate the upper right panel of figure 8 in the original paper.
+
+```@example pai
+as = 0.25:0.25:4.0
+bs = 0.25:0.25:4.0
+
+pai_xys = zeros(length(as), length(bs))
+pai_yxs = zeros(length(as), length(bs))
+c = 2.0
+npts = 2000
+d, τ = 2, 1
+for (i, a) in enumerate(as)
+    for (j, b) in enumerate(bs)
+        sys = nonlinear_sindriver(a = a, b = a, c = c)
+        orbit = trajectory(sys, npts, Ttr = 10000)
+        X, Y = columns(orbit)
+        # Use the segment bootstrap estimator, take the mean of 50 reps over segments of # length L = 200
+        pai_xys[i, j] = pai(X, Y, d, τ, :segment, L = 200, nreps = 50) |> mean
+        pai_yxs[i, j] = pai(Y, X, d, τ, :segment, L = 200, nreps = 50) |> mean
+    end
+end
+```
+
+Now that we have computed the PAI in both directions, we define a measure of directionality as ``\\Delta = cor(y(t), \\tilde{y}(t) | M_{xy}) - cor(x(t), \\tilde{x}(t) | M_{yx})``, so that ``X`` drives ``Y``, then ``\\Delta < 0``.
+
+```@example pai
+Δ = pai_xys .- pai_yxs
+
+clr = cgrad(:magma, categorical = true)
+plot(xlabel = "a", ylabel = "b")
+yticks!((1:length(as), string.(as)))
+xticks!((1:length(bs), string.(bs)))
+heatmap!(Δ, c = clr, logscale = true)
+savefig("heatmap_pai.svg") # hide
+```
+
+![](heatmap_pai.svg)
+
+As expected, ``\Delta < 0`` for all parameter combinations, implying that ``X`` "PAI drives" ``Y``.

--- a/docs/src/pairwise_asymmetric_inference.md
+++ b/docs/src/pairwise_asymmetric_inference.md
@@ -9,7 +9,7 @@ pai
 Let's try to reproduce figure 8 in McCracken & Weigel (2014)[^McCracken2014]. We'll start by defining the their example B (equations 6-7). This system consists of two
 variables ``X`` and ``Y``, where ``X`` drives ``Y``.
 
-```@example pai
+```@example pai_ex
 using CausalityTools, DynamicalSystems, Plots, StatsBase, Statistics, Distributions; gr()
 
 function eom_nonlinear_sindriver(dx, x, p, n)
@@ -45,7 +45,7 @@ savefig("pai_ts.svg") # hide
 
 Now, let's generate such time series for many different values of the parameters `a` and `b`, and compute PAI for fixed `p = 2.0`. This will replicate the upper right panel of figure 8 in the original paper.
 
-```@example pai
+```@example pai_ex
 as = 0.25:0.25:4.0
 bs = 0.25:0.25:4.0
 
@@ -66,9 +66,9 @@ for (i, a) in enumerate(as)
 end
 ```
 
-Now that we have computed the PAI in both directions, we define a measure of directionality as the difference between PAI in the ``X \\to Y`` direction and in the ``Y \\to X`` direction, so that if ``X`` drives ``Y``, then ``\\Delta < 0``.
+Now that we have computed the PAI in both directions, we define a measure of directionality as the difference between PAI in the ``X`` to ``Y`` direction and in the ``Y`` to ``X`` direction, so that if ``X`` drives ``Y``, then ``\\Delta < 0``.
 
-```@example pai
+```@example pai_ex
 Δ = pai_xys .- pai_yxs
 
 clr = cgrad(:magma, categorical = true)

--- a/docs/src/pairwise_asymmetric_inference.md
+++ b/docs/src/pairwise_asymmetric_inference.md
@@ -57,9 +57,8 @@ d, τ = 2, 1
 for (i, a) in enumerate(as)
     for (j, b) in enumerate(bs)
         s = nonlinear_sindriver(a = a, b = a, c = c)
-        orbit = trajectory(s, npts, Ttr = 10000)
-        X, Y = columns(orbit)
-        # Use the segment bootstrap estimator, take the mean of 50 reps over segments of # length L = 200
+        X, Y = columns(trajectory(s, npts, Ttr = 10000))
+        # Use the segment bootstrap estimator, take the mean of 50 reps over segments of length L = 200
         pai_xys[i, j] = pai(X, Y, d, τ, :segment, L = 200, nreps = 50) |> mean
         pai_yxs[i, j] = pai(Y, X, d, τ, :segment, L = 200, nreps = 50) |> mean
     end

--- a/src/CrossMappings/CrossMappings.jl
+++ b/src/CrossMappings/CrossMappings.jl
@@ -6,6 +6,7 @@ using Statistics
 using Distributions
 using StatsBase
 
+include("utils.jl")
 include("ccm.jl")
 
 end # module

--- a/src/CrossMappings/CrossMappings.jl
+++ b/src/CrossMappings/CrossMappings.jl
@@ -8,5 +8,6 @@ using StatsBase
 
 include("utils.jl")
 include("ccm.jl")
+include("pairwise_asymmetric_inference.jl")
 
 end # module

--- a/src/CrossMappings/ccm.jl
+++ b/src/CrossMappings/ccm.jl
@@ -4,8 +4,8 @@ import DelayEmbeddings.Neighborhood: Theiler, bulkisearch, NeighborNumber
 export crossmap
 
 """
-    crossmap(x, y, d, τ; w = 0, correspondence_measure = Statistics.cor) → Float64
-    crossmap(x, y, d, τ, bootstrap_method::Symbol; w = 0, correspondence_measure = Statistics.cor,
+    crossmap(x, y, d, τ; r = 0, correspondence_measure = Statistics.cor) → Float64
+    crossmap(x, y, d, τ, bootstrap_method::Symbol; r = 0, correspondence_measure = Statistics.cor,
         method = :segment, L = ceil(Int, (length(x)-d*τ)*0.2), nreps = 100) → Vector{Float64}
 
 Compute the cross mapping [^Sugihara2012] between `x` and `y`, which is the correspondence (computed using 
@@ -17,9 +17,9 @@ Here, ``y(t)`` are the raw values of the time series `y`, and ``ỹ(t)`` are the
 computed from the out-of-sample embedding ``M_X`` constructed from the time series `x` with 
 embedding dimension `d` and embedding lag `τ`.
 
-The Theiler window `w` indicates how many temporal neighbors of the predictee is to be excluded 
-during the nearest neighbors search (the default `w = 0` excludes only the predictee itself, while 
-`w = 2` excludes the point itself plus its two nearest neighbors in time).
+The Theiler window `r` indicates how many temporal neighbors of the predictee is to be excluded 
+during the nearest neighbors search (the default `r = 0` excludes only the predictee itself, while 
+`r = 2` excludes the point itself plus its two nearest neighbors in time).
 
 If `bootstrap_method` is specified, then `nreps` different bootstrapped estimates of 
 `correspondence_measure(y(t), ỹ(t) | M_x)` are returned. The following bootstrap methods are available:
@@ -34,110 +34,25 @@ If `bootstrap_method` is specified, then `nreps` different bootstrapped estimate
 [^Sugihara2012]: Sugihara, George, et al. "Detecting causality in complex ecosystems." Science (2012): 1227079.[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
 [^Luo2015]: "Questionable causality: Cosmic rays to temperature." Proceedings of the National Academy of Sciences Aug 2015, 112 (34) E4638-E4639; DOI: 10.1073/pnas.1510571112 Ming Luo, Holger Kantz, Ngar-Cheung Lau, Wenwen Huang, Yu Zhou
 """
-function crossmap(x, y, d, τ; correspondence_measure = Statistics.cor, w = 0) 
-    Mₓ = crossmapembed(x, d, τ, CCMEmbedding()) 
-    theiler = Theiler(w); 
-    tree = KDTree(Mₓ)
-    idxs = bulkisearch(tree, Mₓ, NeighborNumber(d+1), theiler)
-    ỹ = copy(y)
+function crossmap(x, y, d, τ; correspondence_measure = Statistics.cor, r = 0) 
+    # Embed `x`
+    Mₓ = crossmapembed(x, d, τ, CCMEmbedding())
 
-    for i in 1:length(Mₓ)
-        J = idxs[i]
-        xᵢ = Mₓ[i]
-        n1 = norm(xᵢ - Mₓ[J[1]])
-        # If distance to nearest neighor is zero, then we get division by zero.
-        # If that is the case, set all weights all to zero.
-        if n1 == 0.0
-            w .= 0.0
-        else
-            w = [exp(-norm(xᵢ - Mₓ[j])/n1) for j in J]
-            w ./= sum(w)
-        end
-        ỹ[i] = sum(w[k]*y[j] for (k, j) in enumerate(J))
-    end
-
-    return correspondence_measure(y, ỹ)
+    # Compute `ỹ | Mₓ` and return `correspondence_measure(ỹ | Mₓ, y).
+    return crossmap_basic(Mₓ, y, d, τ, correspondence_measure = correspondence_measure, r = r)
 end
 
 function crossmap(x, y, d, τ, bootstrap_method::Symbol;
         L = ceil(Int, (length(x) - d * τ) * 0.2), nreps = 100, 
-        w = 0, correspondence_measure = Statistics.cor)
+        r = 0, correspondence_measure = Statistics.cor)
     
+    # Embed `x`
     @assert length(x) == length(y)
     @assert length(x) - d * τ > 0
+    Mₓ = crossmapembed(x, d, τ, CCMEmbedding());
 
-    Mₓ = crossmapembed(x, d, τ, CCMEmbedding()) 
-    theiler = Theiler(w);
-
-    # Compute correlations between out-of-sample target and embedding for `nreps` 
-    # different training sets
-    cors = zeros(nreps)
-
-    # These arrays are re-used.
-    u = zeros(d + 1)
-    w = zeros(d + 1)
-    ỹs = zeros(L)
-
-    for n = 1:nreps
-        # Select training set and keep track of corresponding y-values
-        if bootstrap_method == :random 
-            # Training set is a random embedding vectors. This is method 3 in 
-            # Luo et al. (2015)
-            idxs = StatsBase.sample(1:length(Mₓ), L)
-        elseif bootstrap_method == :segment 
-            # Training set is a random set of L embedding vectors in Mₓ
-            # This is method 2 in Luo et al. (2015), but with added exclusion of 
-            # the predictee from the libraries.
-            startidx = rand(1:length(Mₓ) - L)
-            idxs = startidx:startidx + L - 1
-        else
-            error("$bootstrap_method is not a valid bootstrap method")
-        end
-        training_set = Mₓ[idxs]
-        ys = y[idxs]
-
-        # Find the nearest neighbors of points in the training set
-        tree = KDTree(training_set)
-        idxs_nns = bulkisearch(tree, training_set, NeighborNumber(d+1), theiler)
-        
-        # Reset predictions
-        ỹs .= 0.0
-
-        @inbounds for i in 1:length(training_set) 
-            # For every point xᵢ ∈ training_set
-            xᵢ = training_set[i]
-
-            # Get the indices of its nearest neighbors (in the training set, not the entire Mx)
-            nns_idxs = idxs_nns[i]
-            nns = training_set[nns_idxs]
-
-            # Depending on the input data, we might encounter a case where the distance from xᵢ
-            # to its closest neighbor is indistinguishable from zero. In that case, we encounter
-            # division by zero when computing weights. In that case, we set all weights to zero.
-            dist₁ = norm(xᵢ - nns[1])
-
-            if dist₁ == 0.0
-                w .= 0.0
-            else 
-                for j = 1:d+1
-                    distⱼ = norm(xᵢ - nns[j])
-                    u[j] = exp(-distⱼ / dist₁)
-                end
-                for j = 1:d+1
-                    w[j] = u[j] / sum(u)
-                end
-            end
-
-            # For each weight
-            for j = 1:d+1
-                # Find the scalar value corresponding to this weight
-                idx_nnⱼ = nns_idxs[j]
-                y_scalar = ys[idx_nnⱼ]
-                ỹs[i] += w[j] * y_scalar
-            end
-        end
-        cors[n] = correspondence_measure(ys, ỹs)
-    end
-
-    return cors
+    # Compute `ỹ | Mₓ` and return `nreps` values for `correspondence_measure(ỹ | Mₓ, y),
+    # each value being computed on a random library (sequential or not) consisting of `L` points.
+    return crossmap_bootstrap(Mₓ, y, d, τ, bootstrap_method; L = L, nreps = nreps, r = r, 
+        correspondence_measure = correspondence_measure)
 end

--- a/src/CrossMappings/ccm.jl
+++ b/src/CrossMappings/ccm.jl
@@ -35,7 +35,7 @@ If `bootstrap_method` is specified, then `nreps` different bootstrapped estimate
 [^Luo2015]: "Questionable causality: Cosmic rays to temperature." Proceedings of the National Academy of Sciences Aug 2015, 112 (34) E4638-E4639; DOI: 10.1073/pnas.1510571112 Ming Luo, Holger Kantz, Ngar-Cheung Lau, Wenwen Huang, Yu Zhou
 """
 function crossmap(x, y, d, τ; correspondence_measure = Statistics.cor, w = 0) 
-    Mₓ = embed(x, d, τ); 
+    Mₓ = crossmapembed(x, d, τ, CCMEmbedding()) 
     theiler = Theiler(w); 
     tree = KDTree(Mₓ)
     idxs = bulkisearch(tree, Mₓ, NeighborNumber(d+1), theiler)
@@ -63,10 +63,10 @@ function crossmap(x, y, d, τ, bootstrap_method::Symbol;
         L = ceil(Int, (length(x) - d * τ) * 0.2), nreps = 100, 
         w = 0, correspondence_measure = Statistics.cor)
     
-        @assert length(x) == length(y)
+    @assert length(x) == length(y)
     @assert length(x) - d * τ > 0
 
-    Mₓ = embed(x, d, τ); 
+    Mₓ = crossmapembed(x, d, τ, CCMEmbedding()) 
     theiler = Theiler(w);
 
     # Compute correlations between out-of-sample target and embedding for `nreps` 

--- a/src/CrossMappings/pairwise_asymmetric_inference.jl
+++ b/src/CrossMappings/pairwise_asymmetric_inference.jl
@@ -1,0 +1,145 @@
+export pai
+
+"""
+    pai(x, y, d, τ; w = 0, correspondence_measure = Statistics.cor) → Float64
+    pai(x, y, d, τ, bootstrap_method::Symbol; w = 0, correspondence_measure = Statistics.cor,
+        method = :segment, L = ceil(Int, (length(x)-d*τ)*0.2), nreps = 100) → Vector{Float64}
+
+Compute the pairwise asymmetric inference (PAI; McCracken, 2014)[^McCracken2014] between `x` and `y`.
+Returns the correspondence between original and cross mapped values (the default is 
+`ρ = correspondence_measure(y(t), ỹ(t) | M_xy)`).
+
+PAI is a modification to Sugihara et al. (2012)'s CCM algorithm[^Sugihara2012], where instead of 
+using completely out-of-sample prediction when trying to predict ``y(t)``, values about *both* variables 
+are included in the embedding used to make predictions. Specifically, PAI computes the 
+correspondence between the values ``y(t)`` and the cross-map estimated values ``ỹ(t) | M_xy``,
+where the ``\\tilde{y}(t)`` are the values estimated using the embedding ``M_{xy} = \\{ ( x_t, x_{t-\\tau}, x_{t-2\\tau}, \\ldots, x_{t-(d - 1)\\tau} ) \\}``.
+*Note: a `d+1`-dimensional embedding is used, rather than the `d`-dimensional embedding used for CCM.
+
+Like for the CCM algorithm, the Theiler window `w` indicates how many temporal neighbors of the predictee is to be excluded 
+during the nearest neighbors search (the default `w = 0` excludes only the predictee itself, while 
+`w = 2` excludes the point itself plus its two nearest neighbors in time).
+
+If `bootstrap_method` is specified, then `nreps` different bootstrapped estimates of 
+`correspondence_measure(y(t), ỹ(t) | M_x)` are returned. The following bootstrap methods are available:
+
+- `bootstrap_method = :random` selects training sets of length `L` consisting of randomly selected 
+    points from the embedding ``M_x``  (time ordering does not matter). This is method 3 from Luo 
+    et al. (2015)[^Luo2015], which critiqued the original Sugihara et al. methodology.
+- `bootstrap_method = :segment` selects training sets consisting of time-contiguous segments 
+    (each of lenght `L`) of embedding vectors in ``M_x`` (time ordering matters). This is 
+    method 2 from Luo et al. (2015)[^Luo2015].
+
+[^McCracken2014]: McCracken, James M., and Robert S. Weigel. "Convergent cross-mapping and pairwise asymmetric inference." Physical Review E 90.6 (2014): 062903.
+[^Sugihara2012]: Sugihara, George, et al. "Detecting causality in complex ecosystems." Science (2012): 1227079.[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+[^Luo2015]: "Questionable causality: Cosmic rays to temperature." Proceedings of the National Academy of Sciences Aug 2015, 112 (34) E4638-E4639; DOI: 10.1073/pnas.1510571112 Ming Luo, Holger Kantz, Ngar-Cheung Lau, Wenwen Huang, Yu Zhou
+"""
+function pai(x, y, d, τ; correspondence_measure = Statistics.cor, w = 0) 
+    Mₓy = crossmapembed(x, y, d, τ, PAIEmbedding()) 
+
+    theiler = Theiler(w); 
+    tree = KDTree(Mₓy)
+    idxs = bulkisearch(tree, Mₓy, NeighborNumber(d+1), theiler)
+    ỹ = copy(y)
+
+    for i in 1:length(Mₓy)
+        J = idxs[i]
+        xᵢ = Mₓy[i]
+        n1 = norm(xᵢ - Mₓy[J[1]])
+        # If distance to nearest neighor is zero, then we get division by zero.
+        # If that is the case, set all weights all to zero.
+        if n1 == 0.0
+            w .= 0.0
+        else
+            w = [exp(-norm(xᵢ - Mₓy[j])/n1) for j in J]
+            w ./= sum(w)
+        end
+        ỹ[i] = sum(w[k]*y[j] for (k, j) in enumerate(J))
+    end
+
+    return correspondence_measure(y, ỹ)
+end
+
+
+function pai(x, y, d, τ, bootstrap_method::Symbol;
+        L = ceil(Int, (length(x) - d * τ) * 0.2), nreps = 100, 
+        w = 0, correspondence_measure = Statistics.cor)
+    
+    @assert length(x) == length(y)
+    @assert length(x) - d * τ > 0
+
+    Mₓy = crossmapembed(x, y, d, τ, PAIEmbedding()) 
+    theiler = Theiler(w);
+
+    # Compute correlations between out-of-sample target and embedding for `nreps` 
+    # different training sets
+    cors = zeros(nreps)
+
+    # These arrays are re-used.
+    u = zeros(d + 1)
+    w = zeros(d + 1)
+    ỹs = zeros(L)
+
+    for n = 1:nreps
+        # Select training set and keep track of corresponding y-values
+        if bootstrap_method == :random 
+            # Training set is a random embedding vectors. This is method 3 in 
+            # Luo et al. (2015)
+            idxs = StatsBase.sample(1:length(Mₓy), L)
+        elseif bootstrap_method == :segment 
+            # Training set is a random set of L embedding vectors in Mₓ
+            # This is method 2 in Luo et al. (2015), but with added exclusion of 
+            # the predictee from the libraries.
+            startidx = rand(1:length(Mₓy) - L)
+            idxs = startidx:startidx + L - 1
+        else
+            error("$bootstrap_method is not a valid bootstrap method")
+        end
+        training_set = Mₓy[idxs]
+        ys = y[idxs]
+
+        # Find the nearest neighbors of points in the training set
+        tree = KDTree(training_set)
+        idxs_nns = bulkisearch(tree, training_set, NeighborNumber(d+1), theiler)
+        
+        # Reset predictions
+        ỹs .= 0.0
+
+        @inbounds for i in 1:length(training_set) 
+            # For every point xᵢ ∈ training_set
+            xᵢ = training_set[i]
+
+            # Get the indices of its nearest neighbors (in the training set, not the entire Mx)
+            nns_idxs = idxs_nns[i]
+            nns = training_set[nns_idxs]
+
+            # Depending on the input data, we might encounter a case where the distance from xᵢ
+            # to its closest neighbor is indistinguishable from zero. In that case, we encounter
+            # division by zero when computing weights. In that case, we set all weights to zero.
+            dist₁ = norm(xᵢ - nns[1])
+
+            if dist₁ == 0.0
+                w .= 0.0
+            else 
+                for j = 1:d+1
+                    distⱼ = norm(xᵢ - nns[j])
+                    u[j] = exp(-distⱼ / dist₁)
+                end
+                for j = 1:d+1
+                    w[j] = u[j] / sum(u)
+                end
+            end
+
+            # For each weight
+            for j = 1:d+1
+                # Find the scalar value corresponding to this weight
+                idx_nnⱼ = nns_idxs[j]
+                y_scalar = ys[idx_nnⱼ]
+                ỹs[i] += w[j] * y_scalar
+            end
+        end
+        cors[n] = correspondence_measure(ys, ỹs)
+    end
+
+    return cors
+end

--- a/src/CrossMappings/utils.jl
+++ b/src/CrossMappings/utils.jl
@@ -1,0 +1,17 @@
+abstract type CrossmapEmbedding end
+
+struct CCMEmbedding end
+struct PAIEmbedding end
+
+function crossmapembed(x, d, τ, method::CCMEmbedding)
+    τs = 0:-τ:d*-τ+1
+    Mₓ = genembed(x, τs); 
+    return Mₓ
+end
+
+function crossmapembed(x, y, d, τ, method::PAIEmbedding)
+    τs = [collect(0:-τ:d*-τ+1); 0]
+    js = [repeat([1], d); 2]
+    Mₓy = genembed(Dataset(x, y), τs, js); 
+    return Mₓy
+end

--- a/src/CrossMappings/utils.jl
+++ b/src/CrossMappings/utils.jl
@@ -15,3 +15,104 @@ function crossmapembed(x, y, d, τ, method::PAIEmbedding)
     Mₓy = genembed(Dataset(x, y), τs, js); 
     return Mₓy
 end
+
+function crossmap_basic(Mₓ, y, d, τ; correspondence_measure = Statistics.cor, r = 0)
+    theiler = Theiler(r); 
+    tree = KDTree(Mₓ)
+    idxs = bulkisearch(tree, Mₓ, NeighborNumber(d+1), theiler)
+    ỹ = copy(y)
+
+    for i in 1:length(Mₓ)
+        J = idxs[i]
+        xᵢ = Mₓ[i]
+        n1 = norm(xᵢ - Mₓ[J[1]])
+   
+        # If distance to nearest neighor is zero, then we get division by zero.
+        # If that is the case, set all weights all to zero (or just skip 
+        # computing ỹᵢ, because it is already set to 0).
+        n1 > 0.0 || continue
+        w = [exp(-norm(xᵢ - Mₓ[j])/n1) for j in J]
+        w ./= sum(w)
+        ỹ[i] = sum(w[k]*y[j] for (k, j) in enumerate(J))
+    end
+
+    return correspondence_measure(y, ỹ)
+end
+
+function crossmap_bootstrap(Mₓ, y, d, τ, bootstrap_method::Symbol;
+    L = ceil(Int, (length(y) - d * τ) * 0.2), nreps = 100, 
+    r = 0, correspondence_measure = Statistics.cor)
+
+    theiler = Theiler(r);
+
+    # Compute correlations between out-of-sample target and embedding for `nreps` 
+    # different training sets
+    cors = zeros(nreps)
+
+    # These arrays are re-used.
+    u = zeros(d + 1)
+    w = zeros(d + 1)
+    ỹs = zeros(L)
+
+    for n = 1:nreps
+        # Select training set and keep track of corresponding y-values
+        if bootstrap_method == :random 
+            # Training set is a random embedding vectors. This is method 3 in 
+            # Luo et al. (2015)
+            idxs = StatsBase.sample(1:length(Mₓ), L)
+        elseif bootstrap_method == :segment 
+            # Training set is a random set of L embedding vectors in Mₓ
+            # This is method 2 in Luo et al. (2015), but with added exclusion of 
+            # the predictee from the libraries.
+            startidx = rand(1:length(Mₓ) - L)
+            idxs = startidx:startidx + L - 1
+        else
+            error("$bootstrap_method is not a valid bootstrap method")
+        end
+        training_set = Mₓ[idxs]
+        ys = y[idxs]
+
+        # Find the nearest neighbors of points in the training set
+        tree = KDTree(training_set)
+        idxs_nns = bulkisearch(tree, training_set, NeighborNumber(d+1), theiler)
+        
+        # Reset predictions
+        ỹs .= 0.0
+
+        @inbounds for i in 1:length(training_set) 
+            # For every point xᵢ ∈ training_set
+            xᵢ = training_set[i]
+
+            # Get the indices of its nearest neighbors (in the training set, not the entire Mx)
+            nns_idxs = idxs_nns[i]
+            nns = training_set[nns_idxs]
+
+            # Depending on the input data, we might encounter a case where the distance from xᵢ
+            # to its closest neighbor is indistinguishable from zero. In that case, we encounter
+            # division by zero when computing weights. In that case, set weights to zero (but in
+            # practice, just continue to the next step, because ỹᵢ will is already initialized to 0)
+            dist₁ = norm(xᵢ - nns[1])
+            dist₁ > 0.0 || continue
+
+            for j = 1:d+1
+                distⱼ = norm(xᵢ - nns[j])
+                u[j] = exp(-distⱼ / dist₁)
+            end
+            s = sum(u)
+            for j = 1:d+1
+                w[j] = u[j] / s
+            end
+            
+            # For each weight
+            for j = 1:d+1
+                # Find the scalar value corresponding to this weight
+                idx_nnⱼ = nns_idxs[j]
+                y_scalar = ys[idx_nnⱼ]
+                ỹs[i] += w[j] * y_scalar
+            end
+        end
+        cors[n] = correspondence_measure(ys, ỹs)
+    end
+
+    return cors
+end

--- a/test/methods/test_crossmapping.jl
+++ b/test/methods/test_crossmapping.jl
@@ -2,11 +2,14 @@ using CausalityTools, StatsBase
 
 @testset "Cross mapping" begin
 
-	@testset "Prediction lags" begin
-	    x, y = rand(100), rand(100)
-	    @test crossmap(x, y, 3, 1) isa Float64
-		@test crossmap(x, y, 3, 1, :random) isa Vector{Float64}
-		@test crossmap(x, y, 3, 1, :segment) isa Vector{Float64}
-	end
+	x, y = rand(100), rand(100)
+	@test crossmap(x, y, 3, 1) isa Float64
+	@test crossmap(x, y, 3, 1, :random) isa Vector{Float64}
+	@test crossmap(x, y, 3, 1, :segment) isa Vector{Float64}
+end
 
+@testset "Pairwise asymmetric inference" begin
+	@test pai(x, y, 3, 1) isa Float64
+	@test pai(x, y, 3, 1, :random) isa Vector{Float64}
+	@test pai(x, y, 3, 1, :segment) isa Vector{Float64}
 end


### PR DESCRIPTION
An implementation of the CCM-like method from McCracken (2014). The docs are [here](https://juliadynamics.github.io/CausalityTools.jl/previews/PR149/).

The cross mapping code is identical to CCM; the only thing differing is the embedding step. I therefore separated the cross mapping code into separate functions `crossmap_basic` and `crossmap_bootstrap`, and use these in the `crossmap` and `pai` functions after the embedding steps.