### PR TITLE
Test Dataset explicitly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using CausalityTools
 import DelayEmbeddings: Dataset
 import DynamicalSystemsBase: DiscreteDynamicalSystem, ContinuousDynamicalSystem
 
+x, y = rand(100), rand(100)
+@test Dataset(x, y) isa Dataset
 
 include("methods/test_smeasure.jl")
 include("methods/test_joint_distance_distribution.jl")


### PR DESCRIPTION
Trying to locate the CI error ([here](https://github.com/JuliaDynamics/CausalityTools.jl/pull/153)) when constructing `Dataset`s from time series.

The only test being run now is

```
using Test
x, y = rand(100), rand(100)
@test Dataset(x, y) isa Dataset
```