### PR TITLE
WIP: Compression complexity for univariate and multivariate time series

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,9 @@ PAGES = [
         "generalized_entropy.md",
         "info_estimators.md",
     ],
+    "Compression complexity" => [
+        "compression_complexity.md",
+    ],
 
     "example_systems.md",
     "Utilities" => [

--- a/docs/src/compression_complexity.md
+++ b/docs/src/compression_complexity.md
@@ -1,0 +1,12 @@
+# Compression complexity
+
+```@docs
+compression_complexity
+```
+
+## Algorithms
+
+```@docs
+EffortToCompress
+EffortToCompressSlidingWindow
+```

--- a/src/CausalityTools.jl
+++ b/src/CausalityTools.jl
@@ -17,6 +17,8 @@ module CausalityTools
     include("PredictiveAsymmetry/PredictiveAsymmetry.jl")
     include("example_systems/ExampleSystems.jl")
 
+    include("complexity_measures/compression_complexity.jl")
+
     using Requires 
     function __init__()
         #@require UncertainData="dcd9ba68-c27b-5cea-ae21-829cd07325bf" begin

--- a/src/complexity_measures/compression_complexity.jl
+++ b/src/complexity_measures/compression_complexity.jl
@@ -1,0 +1,49 @@
+abstract type CompressionComplexityAlgorithm end
+
+export compression_complexity
+
+"""
+    compression_complexity(x, algorithm::EffortToCompress) → N    
+    compression_complexity(x, algorithm::EffortToCompressSlidingWindow) → Vector{N}
+
+Compute the compression complexity of the pre-binned/pre-symbolized (integer-valued)
+univariate (`Vector{Int}`) or multivariate (`Dataset`) time series, using the given 
+`algorithm`.
+
+See also: [`EffortToCompress`](@ref), [`EffortToCompressSlidingWindow`](@ref).
+
+## Returns
+
+See the documentation for individual algorithms for details on return values.
+
+Some `algorithm`s have a sliding window version that may be optimized for repeated 
+application. When using these algorithms, a vector of compression complexity measures - 
+one for each window - is returned.
+
+## Examples
+
+### Effort-to-compress
+
+```julia
+# A univariate time series (no need to specify `alphabet_size`)
+ts = [1, 2, 1, 2, 1, 1, 1, 2]
+compression_complexity(x, EffortToCompress())
+```
+
+```julia
+# A multivariate time series from a three-letter alphabet
+ts = rand(0:2, 30)
+compression_complexity(x, EffortToCompress(alphabet_size = 3))
+```
+
+```julia
+ts = rand(0:1, 100)
+alg = EffortToCompressSlidingWindow(window_length = 10, step = 5)
+compression_complexity(x, alg)
+```
+"""
+function compression_complexity end
+
+include("effort_to_compress/effort_to_compress.jl")
+
+

--- a/src/complexity_measures/effort_to_compress/effort_to_compress.jl
+++ b/src/complexity_measures/effort_to_compress/effort_to_compress.jl
@@ -1,0 +1,65 @@
+export EffortToCompress, EffortToCompressSlidingWindow
+
+"""
+    EffortToCompress(; normalize = false, alphabet_size = nothing)
+
+The effort-to-compress (ETC)[^Nagaraj2013] algorithm can be used to compute the 
+compression complexity of a time series.
+
+## Normalization
+
+If `normalize == false`, then computes the number of compression steps `N` it takes for the 
+symbol sequence to reach zero entropy (either a constant sequence, or a length-1 sequence).
+
+For a length-`N` sequence, the maximum number of possible compression steps is `N-1`.
+If `normalize == true`, then the ETC value is normalized to `N-1`, yielding a number on 
+`[0, 1]`, where `0` indicates minimal compression complexity and `1` indicates maximal 
+compression complexity. 
+
+## Alphabet size
+
+The `alphabet_size` is the number of possible values the time series can take. For example,
+a binary time series, `alphabet_size = 2`. For a five-box binned time series, 
+`alphabet_size = 5`. 
+
+The `alphabet_size` parameter must be given a positive integer value in order to compute 
+ETC for multivariate time series. For univariate time series, `alphabet_size` is ignored.
+
+[^Nagaraj2013]: Nagaraj, N., Balasubramanian, K., & Dey, S. (2013). A new complexity 
+    measure for time series analysis and classification. The European Physical Journal 
+    Special Topics, 222(3), 847-860.
+"""
+struct EffortToCompress
+    alphabet_size::Union{Nothing, Int}
+    normalize::Bool
+
+    function EffortToCompress(; 
+        alphabet_size::Union{Nothing, Int} = nothing,
+        normalize = false)
+        return new(alphabet_size, normalize)
+    end
+end
+
+"""
+    EffortToCompressSlidingWindow(; normalize::bool = false, window_size = 15, step = 1)
+
+Like [`EffortToCompress`](@ref), but applied on a constant-length sliding window across 
+the time series, using the given `step` and `window_size`.
+"""
+struct EffortToCompressSlidingWindow
+    alphabet_size::Union{Nothing, Int}
+    normalize::Bool
+    window_size::Int
+    step::Int
+    EffortToCompressSlidingWindow(; 
+        alphabet_size::Union{Nothing, Int} = nothing,
+        normalize::Bool = false,
+        window_size::Int = 15,
+        step::Int = 1,
+        ) = new(alphabet_size, normalize, window_size, step)
+end
+
+
+include("etc_utils.jl")
+include("etc_univariate.jl")
+include("etc_multivariate.jl")

--- a/src/complexity_measures/effort_to_compress/etc_multivariate.jl
+++ b/src/complexity_measures/effort_to_compress/etc_multivariate.jl
@@ -1,0 +1,43 @@
+using DelayEmbeddings
+export symbol_sequence
+
+function vecints_to_int(x::AbstractVector{J}, base) where J <: Integer
+    s = zero(J)
+    for xᵢ in x
+       s = s * base + xᵢ
+    end
+    return s
+end
+
+"""
+    symbol_sequence(x::Dataset{D, T}, alphabet_size) where {D <: Integer, T <: Integer}
+
+Create an encoded one-dimensional integer symbol sequence from a `D`-dimensional 
+symbol sequence `x`, assuming that the alphabet used for the original symbolization 
+has `alphabet_size` possible symbols.
+
+In the context of the effort-to-compress algorithm, `x` would typically 
+be a sub-dataset as obtained by `view(d::Dataset, indices)`.
+"""
+function symbol_sequence(x::AbstractDataset{D, T}, alphabet_size) where {D, T}
+    encoded_sequence = [vecints_to_int(xᵢ, alphabet_size) for xᵢ in x]
+end
+
+
+function compression_complexity(x::AbstractDataset{D, T}, algorithm::EffortToCompress) where {D, T}
+    !isnothing(algorithm.alphabet_size) || throw(ArgumentError("Alphabet size must be specified when input is multivariate"))
+    algorithm.alphabet_size >= 2 || throw(ArgumentError("Alphabet size must be at least 2."))
+    encoded_sequence = symbol_sequence(x, algorithm.alphabet_size)
+    return compression_complexity(encoded_sequence, algorithm)
+end
+
+function compression_complexity(x::AbstractDataset{D, T}, algorithm::EffortToCompressSlidingWindow) where {D, T}
+    !isnothing(algorithm.alphabet_size) || throw(ArgumentError("Alphabet size must be specified when input is multivariate"))
+    algorithm.alphabet_size >= 2 || throw(ArgumentError("Alphabet size must be at least 2."))
+    
+    encoded_sequence = symbol_sequence(x, algorithm.alphabet_size)
+    windows = get_windows(x, algorithm.window_size, algorithm.step)
+    alg = EffortToCompress(normalize = algorithm.normalize)
+    
+    return @views [compression_complexity(encoded_sequence[w], alg) for w in windows]
+end

--- a/src/complexity_measures/effort_to_compress/etc_univariate.jl
+++ b/src/complexity_measures/effort_to_compress/etc_univariate.jl
@@ -1,0 +1,88 @@
+using Entropies, StatsBase
+export get_windows
+
+function compress!(x::AbstractVector{T}, 
+        symbol_sequence::Vector{String}, 
+        sorted_sequence::Vector{String}, 
+        unique_symbols::Vector{String}, 
+        frequency_of_symbols::Vector{Int}; 
+        replacement_strategy::ReplacementStrategyInCaseOfEquality = PickFirst()
+        ) where {T <: Integer}
+
+    if (length(x) == 1)
+        return x
+    end
+
+    # With two-letter symbols, the last entry of `x` enters the `length(x)-1`-th symbol.
+    kmax = length(x) - 1
+    make_symbols!(symbol_sequence, sorted_sequence, x, kmax)
+    estimate_histogram!(frequency_of_symbols, unique_symbols, sorted_sequence, kmax)
+
+    return substituted_sequence(x, 
+        symbol_sequence, 
+        frequency_of_symbols, 
+        unique_symbols, 
+        kmax, 
+        replacement_strategy)
+end
+
+function compress(x::AbstractVector{T}; 
+        replacement_strategy::ReplacementStrategyInCaseOfEquality = PickFirst()
+        ) where {T <: Integer}
+
+    if (length(x) == 1)
+        return x
+    end
+
+    # With two-letter symbols, the last entry of `x` enters the `length(x)-1`-th symbol.
+    kmax = length(x) - 1
+
+    symbol_sequence = Vector{String}(undef, kmax)
+    sorted_sequence = Vector{String}(undef, kmax)
+    unique_symbols = Vector{String}(undef, kmax)
+    frequency_of_symbols = zeros(Int, kmax)
+
+    return compress!(x, symbol_sequence, sorted_sequence, unique_symbols, frequency_of_symbols; replacement_strategy=replacement_strategy)
+end
+
+
+function compression_complexity(x::AbstractVector, algorithm::EffortToCompress)
+    # With two-letter symbols, the last entry of `x` enters the `length(x)-1`-th symbol.
+    kmax = length(x) - 1
+
+    # Pre-allocate for repeated use (in the worst case, `kmax - 1` compressions occur)
+    # TODO: pre-allocation doesn't really do anything at the moment. Need to fix 
+    # indexing and re-initialization in `compress!` and its sub-functions first.
+    # Initializing here for every call will do for now.
+    symbol_sequence = Vector{String}(undef, kmax)
+    sorted_sequence = Vector{String}(undef, kmax)
+    unique_symbols = Vector{String}(undef, kmax)
+    frequency_of_symbols = zeros(Int, kmax)
+
+    # The ETC complexity measure records how many compression steps it takes to reach
+    # a zero-entropy (a single-element or constant) symbol sequence. We use a float here
+    # to ensure type-stability if the value is to be normalized.
+    N = 0.0
+
+    # Keep track of how many of the sequence symbols have been compressed.
+    n_reduced = 0
+
+    new_x = copy(x)
+    while genentropy(Dataset(new_x), CountOccurrences()) > 0 && length(new_x) > 1
+        symbol_sequence .= ""
+        sorted_sequence .= ""
+        unique_symbols .= ""
+        frequency_of_symbols .= 0
+        new_x = compress(new_x)
+        N += 1
+    end
+
+    return algorithm.normalize ? N/kmax : N
+end
+
+function compression_complexity(x::AbstractVector{T}, 
+        algorithm::EffortToCompressSlidingWindow) where {T <: Integer}
+    windows = get_windows(x, algorithm.window_size, algorithm.step)
+    alg = EffortToCompress(normalize = algorithm.normalize)
+    return @views [compression_complexity(x[window], alg) for window in windows]
+end

--- a/src/complexity_measures/effort_to_compress/etc_utils.jl
+++ b/src/complexity_measures/effort_to_compress/etc_utils.jl
@@ -1,0 +1,126 @@
+using StatsBase
+using Entropies
+export get_windows
+
+# TODO: fix indexing and re-initialization, so this function can be re-used without 
+# providing newly initialized `frequency_of_symbols`, `unique_symbols` and `sorted_sequence`
+# It works for now, but initialization of the arrays need to happen *before* calling this 
+# function.
+"""
+estimate_histogram!(frequency_of_symbols, unique_symbols, sorted_sequence, kmax::Int) → Int
+
+Count the occurrences of each of the unique symbols in `sorted_sequence`. The results
+are written into the pre-allocated arrays `frequency_of_symbols` and `unique_symbols`.
+Assummes `length(sorted_sequence) >= 2`.
+
+This is used for determining which symbols to substitute in a given iteration of the 
+[`effort_to_compress`](@ref) algorithm. Because the [`effort_to_compress`](@ref) algorithm 
+is intented to be used repeatedly in real applications, pre-allocation is necessary for 
+efficiency. Therefore, this function assumes a fixed-length pre-allocated 
+`sorted_sequence`-vector, for which we consider the elements at indices `1:kmax` (as 
+symbols are substituted in [`effort_to_compress`](@ref), `kmax` decreases).
+
+Returns the number of unique elements found in `sorted_sequence`.
+"""
+function estimate_histogram!(frequency_of_symbols, unique_symbols, sorted_sequence, 
+    kmax::Int)
+    frequency_of_symbols .= 0
+    n_unique = 1
+    
+    unique_symbols[n_unique] = sorted_sequence[n_unique]
+    frequency_of_symbols[n_unique] = 1
+
+    i = 1
+    while i < kmax
+        i += 1
+        last = sorted_sequence[i - 1]
+        next = sorted_sequence[i]
+        if last == next
+            frequency_of_symbols[n_unique] += 1
+        else
+            n_unique += 1
+            unique_symbols[n_unique] = next
+            frequency_of_symbols[n_unique] += 1
+        end
+    end
+
+    #@show "histogram: ", frequency_of_symbols, unique_symbols, sorted_sequence
+
+end
+
+
+"""
+    ReplacementStrategyInCaseOfEquality
+
+How to decide which symbol to replace in case two or more symbols have the same frequency.
+"""
+abstract type ReplacementStrategyInCaseOfEquality end
+
+""" 
+    PickFirst <: ReplacementStrategyInCaseOfEquality
+
+Pick the first element (according to the sorting algorithm used).
+"""
+struct PickFirst <: ReplacementStrategyInCaseOfEquality end
+
+
+
+"""
+Return the sequence where the element with the highest frequency is replaced by 
+the new symbol `replacement_symbol`.
+"""
+function substituted_sequence(x::AbstractVector{T}, 
+        symbol_sequence, frequency_of_symbols, unique_symbols, 
+        kmax::Int, replacement_strategy::PickFirst) where T <: Integer
+    
+    replacement_value = maximum(x) + 1
+
+    # The new x will always be smaller than the original x.
+    # We don't know how much smaller, so reserve sufficient space.
+    new_x = Vector{T}(undef, 0)
+    sizehint!(new_x, length(x))
+    
+    idx_max = argmax(@view frequency_of_symbols[1:kmax])
+    symbol_to_replace = (@view unique_symbols[1:kmax])[idx_max]
+    indices_to_replace = @views findall(xᵢ -> xᵢ == symbol_to_replace, symbol_sequence[1:kmax])
+    j = 1
+
+    while j <= length(x)
+        if j in indices_to_replace
+            push!(new_x, replacement_value)
+            j += 2
+        else
+            if (j <= length(x))
+                push!(new_x, x[j])
+                j += 1
+            end
+        end
+    end
+
+    # Shrink new vector to its size
+    sizehint!(new_x, length(new_x))
+
+    return new_x
+end
+
+"""
+Fill the pre-allocated `symbol_sequence` vector with two-letter symbols made from the 
+elements `x[1:kmax+1]`. Also, sort the sequence and write in-place to the pre-allocated
+`sorted_sequence` vector.
+"""
+function make_symbols!(symbol_sequence, sorted_sequence, x, kmax::Int) 
+    for j = 1:kmax
+        symbol_sequence[j] = make_symbol(x, j)
+    end
+
+
+    sorted_sequence[1:kmax] .= symbol_sequence[1:kmax]
+    sort!(sorted_sequence, alg = Base.Sort.InsertionSort)
+end
+
+make_symbol(x, i::Int) = @views "$(x[i])$(x[i+1])"
+make_symbol_svec(x, i::Int) = @views SVector(x[i], x[i+1])
+
+function get_windows(x, window_length, step::Int = 1)
+    [i:i+window_length for i in 1:step:length(x)-window_length]
+end

--- a/test/complexity_measures/test_effort_to_compress.jl
+++ b/test/complexity_measures/test_effort_to_compress.jl
@@ -1,0 +1,56 @@
+using Test
+
+@testset "Effort to compress (ETC)" begin 
+    @testset "ETC univariate" begin 
+
+        
+        x1 = [1, 2, 1, 2, 1, 1, 1, 2]
+        x2 = [0, 1, 0, 1, 0, 1, 0, 1]
+        x3 = [0, 1, 0, 0, 1, 1, 1, 0]
+        alg = EffortToCompress(normalize = false)
+        @test compression_complexity(x1, alg) == 5.0
+        @test compression_complexity(x2, alg) == 1.0
+        @test compression_complexity(x3, alg) == 6.0
+        @test compression_complexity([1], alg) == 0.0
+
+        alg_norm = EffortToCompress(normalize = true)
+        @test compression_complexity(x3, alg_norm) == 6.0 / (length(x3) - 1)
+
+        # Sliding windows
+        ts = rand(0:3, 50)
+        alg = EffortToCompressSlidingWindow(window_size = 10, step = 2)
+        windows = get_windows(ts, alg.window_size, alg.step)
+        compression_complexity(ts, alg)
+        @test length(compression_complexity(ts, alg)) == length(windows)
+        @test all(compression_complexity(ts, alg) .>= 0)
+    end
+
+    @testset "ETC multivariate" begin
+        x1 = [0, 0, 1, 0]
+        x2 = [1, 0, 1, 0]
+        x3 = [1, 1, 1, 1]
+        x4 = [0, 1, 1, 1]
+
+        @test symbol_sequence(Dataset(x1, x2, x3, x4), 2) == [6, 3, 15, 3]
+        @test symbol_sequence(Dataset(x1, x3, x4), 2) == [2, 3, 7, 3]
+        @test compression_complexity(Dataset(x1, x2, x3, x4), EffortToCompress(alphabet_size = 2)) == 3.0
+
+        # Sliding window
+        x1 = rand(0:1, 100)
+        x2 = rand(0:1, 100)
+        x3 = rand(0:1, 100)
+        x4 = rand(0:1, 100)
+        data = Dataset(x1, x2, x3, x4)
+        window_size = 10
+        step = 2
+        alg = EffortToCompressSlidingWindow(
+            alphabet_size = 2, 
+            window_size = window_size, 
+            step = step)
+        
+        windows = get_windows(data, window_size, step)
+        res = compression_complexity(data, alg)
+        @test length(res) == length(windows)
+        @test all(res .>= 0)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,6 @@ include("methods/test_crossmapping.jl")
 include("systems/discrete/test_discrete_systems.jl")
 include("systems/continuous/test_continuous_systems.jl")
 
+include("complexity_measures/test_effort_to_compress.jl")
+
 #include("integrations/test_uncertaindata_integration.jl")


### PR DESCRIPTION
Implements the effort-to-compress algorithm that underlies the Compression-Complexity Causality (CCC) in #161.

I've decided on a dispatch-on-algorithm approach to allow a cleaner interface in the case that future compression complexity measures (e.g. Lempel-Siv complexity) are added. The syntax is `compression_complexity(x, algorithm::CompressionComplexityAlgorithm)`. 

For effort-to-compress, this becomes `compression_complexity(x, EffortToCompress())`.


TODO:
- [x] Uni- and multivariate effort-to-compress.
- [ ] Joint effort-to-compress.

