### PR TITLE
`mutualinfo` docstring

### DIFF
--- a/src/methods/infomeasures/marginal_encodings.jl
+++ b/src/methods/infomeasures/marginal_encodings.jl
@@ -75,12 +75,14 @@ function marginal_encodings(est::ValueHistogram{<:RectangularBinning}, x::Vector
     joint_bins = reduce(vcat, bins)
     idxs = size.(x, 2) #each input can have different dimensions
     s = 1
-    encodings = Vector{Dataset}(undef, length(idxs))
+    encodings = Vector{Vector}(undef, 0)
     for (i, cidx) in enumerate(idxs)
         variable_subset = s:(s + cidx - 1)
         s += cidx
         y = @views joint_bins[:, variable_subset]
-        encodings[i] = Dataset(y)
+        for j in size(y, 2)
+            push!(encodings, y[:, j])
+        end
     end
 
     return encodings

--- a/src/methods/infomeasures/mutualinfo/MIShannon.jl
+++ b/src/methods/infomeasures/mutualinfo/MIShannon.jl
@@ -10,7 +10,7 @@ The Shannon mutual information ``I^S(X; Y)``.
 ## Usage
 
 - Use with [`independence`](@ref) to perform a formal hypothesis test for pairwise dependence.
-- Use with [`mutualinfo`](@ref) to compute the raw mutual information. 
+- Use with [`mutualinfo`](@ref) to compute the raw mutual information.
 
 
 ## Discrete definition

--- a/src/methods/infomeasures/mutualinfo/mutualinfo.jl
+++ b/src/methods/infomeasures/mutualinfo/mutualinfo.jl
@@ -97,10 +97,10 @@ distributions from the joint distribution.
 | Estimator                    | Principle           | [`MIShannon`](@ref) | [`MITsallisFuruichi`](@ref) | [`MITsallisMartin`](@ref) | [`MIRenyiJizba`](@ref) | [`MIRenyiSarbu`](@ref) |
 | ---------------------------- | ------------------- | :-----------------: | :-------------------------: | :-----------------------: | :--------------------: | :--------------------: |
 | [`Contingency`](@ref)        | Contingency table   |         ✓          |             ✓              |            ✓             |           ✓           |           ✓            |
-| [`CountOccurrences`](@ref)   | Frequencies         |         ✓          |             ✓              |            ✓             |           ✓           |           x            |
-| [`ValueHistogram`](@ref)     | Binning (histogram) |         ✓          |             ✓              |            ✓             |           ✓           |           x            |
-| [`SymbolicPermuation`](@ref) | Ordinal patterns    |         ✓          |             ✓              |            ✓             |           ✓           |           x            |
-| [`Dispersion`](@ref)         | Dispersion patterns |         ✓          |             ✓              |            ✓             |           ✓           |           x            |
+| [`CountOccurrences`](@ref)   | Frequencies         |         ✓          |             ✓              |            ✓             |           ✓           |           ✖            |
+| [`ValueHistogram`](@ref)     | Binning (histogram) |         ✓          |             ✓              |            ✓             |           ✓           |           ✖            |
+| [`SymbolicPermuation`](@ref) | Ordinal patterns    |         ✓          |             ✓              |            ✓             |           ✓           |           ✖            |
+| [`Dispersion`](@ref)         | Dispersion patterns |         ✓          |             ✓              |            ✓             |           ✓           |           ✖            |
 """
 function mutualinfo(measure::MutualInformation, est::ProbabilitiesEstimator, x, y)
     return estimate(measure, est, x, y)


### PR DESCRIPTION
- Fixes a bug for `marginal_encodings(::ValueHistogram{RectangularBinning}, ...)`.
- Fixes #213.  With the above fix, the current table in the `mutualinfo` docstring is correct.