### PR TITLE
PartialCorrelation with `LocalPermutation`

### DIFF
--- a/src/independence_tests/local_permutation/LocalPermutationTest.jl
+++ b/src/independence_tests/local_permutation/LocalPermutationTest.jl
@@ -72,10 +72,11 @@ instead of `Z` and we `I(X; Y)` and `Iₖ(X̂; Y)` instead of `I(X; Y | Z)` and
 
 ## Compatible measures
 
-| Measure              |       Pairwise       | Conditional | Requires `est` |
-| -------------------- | :------------------: | :---------: | :------------: |
-| [`CMIShannon`](@ref) |          ✖           |     ✓       |      Yes       |
-| [`TEShannon`](@ref)  |          ✓           |     ✓       |      Yes       |
+| Measure                      |       Pairwise       | Conditional | Requires `est` |
+| ---------------------------- | :------------------: | :---------: | :------------: |
+| [`PartialCorrelation`](@ref) |          ✖           |     ✓       |      No        |
+| [`CMIShannon`](@ref)         |          ✖           |     ✓       |      Yes       |
+| [`TEShannon`](@ref)          |          ✓           |     ✓       |      Yes       |
 
 The `LocalPermutationTest` is only defined for conditional independence testing.
 Exceptions are for measures like [`TEShannon`](@ref), which use conditional
@@ -191,9 +192,8 @@ end
 # This method takes `measure` and `est` explicitly, because for some measures
 # like `TEShannon`, `test.measure` may be converted to some other measure before
 # computing the test statistic.
-function permuted_Îs(X, Y, Z, measure::AssociationMeasure, est, test::LocalPermutationTest)
+function permuted_Îs(X, Y, Z, measure, est, test)
     rng, kperm, nshuffles, replace, w = test.rng, test.kperm, test.nshuffles, test.replace, test.w
-    @assert length(X) == length(Y) == length(Z)
     N = length(X)
     test.kperm < N || throw(ArgumentError("kperm must be smaller than input data length"))
 
@@ -241,4 +241,3 @@ end
 
 # Concrete implementations
 include("transferentropy.jl")
-

--- a/src/independence_tests/local_permutation/LocalPermutationTest.jl
+++ b/src/independence_tests/local_permutation/LocalPermutationTest.jl
@@ -63,7 +63,7 @@ The algorithm is as follows:
         Repeat for `i = 1, 2, …, n` and obtain the shuffled `X̂ = [x̂₁, x̂₂, …, x̂ₙ]`.
     * Compute the conditional independence statistic `Iₖ(X̂; Y | Z)`.
     * Let `Î[k] = Iₖ(X̂; Y | Z)`.
-6. Compute the p-value as `count(Î[k] .<= I) / nshuffles).
+6. Compute the p-value as `count(Î[k] .<= I) / nshuffles)`.
 
 In additional to the conditional variant from Runge (2018), we also provide a pairwise
 version, where the shuffling procedure is identical, except neighbors in `Y` are used

--- a/src/independence_tests/local_permutation/LocalPermutationTest.jl
+++ b/src/independence_tests/local_permutation/LocalPermutationTest.jl
@@ -74,8 +74,8 @@ instead of `Z` and we `I(X; Y)` and `Iₖ(X̂; Y)` instead of `I(X; Y | Z)` and
 
 | Measure              |       Pairwise       | Conditional | Requires `est` |
 | -------------------- | :------------------: | :---------: | :------------: |
-| [`CMIShannon`](@ref) | ✓ (non-conditional) |     ✓      |      Yes       |
-| [`TEShannon`](@ref)  |          ✓          |     ✓      |      Yes       |
+| [`CMIShannon`](@ref) |          ✖           |     ✓       |      Yes       |
+| [`TEShannon`](@ref)  |          ✓           |     ✓       |      Yes       |
 
 The `LocalPermutationTest` is only defined for conditional independence testing.
 Exceptions are for measures like [`TEShannon`](@ref), which use conditional

--- a/src/methods/correlation/correlation.jl
+++ b/src/methods/correlation/correlation.jl
@@ -1,5 +1,3 @@
-abstract type ParametricAssociationMeasure end
-
 include("pearson_correlation.jl")
 include("partial_correlation.jl")
 include("distance_correlation.jl")

--- a/src/methods/correlation/distance_correlation.jl
+++ b/src/methods/correlation/distance_correlation.jl
@@ -17,7 +17,7 @@ potentially nonlinear associations between pairs of variables.
 - Use with [`distance_correlation`](@ref) to compute the raw distance correlation
     coefficient.
 """
-struct DistanceCorrelation end
+struct DistanceCorrelation <: AssociationMeasure end
 
 """
     distance_correlation(x, y) → dcor ∈ [0, 1]

--- a/src/methods/correlation/partial_correlation.jl
+++ b/src/methods/correlation/partial_correlation.jl
@@ -2,7 +2,7 @@ export partial_correlation
 export PartialCorrelation
 
 """
-    PartialCorrelation
+    PartialCorrelation <: AssociationMeasure
 
 The correlation of two variables, with the effect of a set of conditioning
 variables removed.
@@ -38,7 +38,7 @@ In practice, we compute the estimate
 
 where ``\\hat{P} = \\hat{\\Sigma}^{-1}`` is the sample precision matrix.
 """
-struct PartialCorrelation <: ParametricAssociationMeasure end
+struct PartialCorrelation <: AssociationMeasure end
 
 """
     partial_correlation(x::VectorOrDataset, y::VectorOrDataset,
@@ -50,7 +50,7 @@ function partial_correlation(x::VectorOrDataset, y::VectorOrDataset, z::ArrayOrD
     return estimate(PartialCorrelation(), x, y, z...)
 end
 
-# Common interface for higher-level methods.
+# Compatibility with `independence`
 function estimate(::PartialCorrelation, x::VectorOrDataset, y::VectorOrDataset,
         conds::ArrayOrDataset...)
     dimension(x) == 1 || throw(ArgumentError("Input `x` must be 1-dimensional"))
@@ -61,6 +61,11 @@ function estimate(::PartialCorrelation, x::VectorOrDataset, y::VectorOrDataset,
     precision_matrix = invert_cov(cov)
     return partial_correlation_from_precision(precision_matrix, 1, 2)
 end
+
+function estimate(measure::PartialCorrelation, est::Nothing, x, y, z)
+    return estimate(measure, x, y, z)
+end
+
 
 function invert_cov(cov::AbstractMatrix)
     if det(cov) ≈ 0.0

--- a/src/methods/correlation/pearson_correlation.jl
+++ b/src/methods/correlation/pearson_correlation.jl
@@ -56,6 +56,10 @@ function estimate(measure::PearsonCorrelation,
     return ρ
 end
 
+function estimate(measure::PearsonCorrelation, est::Nothing, x, y)
+    return estimate(measure, x, y)
+end
+
 # Silly, but 1-dimensional datasets needs special indexing (because each point is a vector,
 # not a value).
 pt_generator(x::AbstractDataset{1}) = (x[1] for x in x)

--- a/src/methods/correlation/pearson_correlation.jl
+++ b/src/methods/correlation/pearson_correlation.jl
@@ -24,7 +24,7 @@ for real-valued random variables ``X`` and ``Y`` with associated samples
 where ``\\bar{x}`` and ``\\bar{y}`` are the means of the observations ``x_k`` and ``y_k``,
 respectively.
 """
-struct PearsonCorrelation end
+struct PearsonCorrelation <: AssociationMeasure end
 
 """
     pearson_correlation(x::VectorOrDataset, y::VectorOrDataset)


### PR DESCRIPTION
This PR removes some type requirements to make compatibility with more measures possible. As a result, `PartialCorrelation` can now be used with `LocalPermutation`