### PR TITLE
Make `TransferEntropyEstimator`s compatible with `independence`

### DIFF
--- a/src/independence_tests/surrogate/transferentropy.jl
+++ b/src/independence_tests/surrogate/transferentropy.jl
@@ -4,33 +4,50 @@ using TimeseriesSurrogates: surrogenerator
 
 const EmbeddingTypes = Union{EmbeddingTE, OptimiseTraditional}
 function marginals_and_surrogenerator(emb::EmbeddingTE, surrogate::Surrogate, x::AbstractVector...; rng)
-    if emb.dS != 1
+    if emb.dS > 1 && surrogate ∉ [RandomShuffle]
         throw(ArgumentError("Dimension of source embedding must be 1 to be applicable with surrogate methods"))
     end
     S, T, T⁺, C = individual_marginals_te(emb, x...)
     Ŝ = surrogenerator(S[:, 1], surrogate, rng)
 
-    return Ŝ, T⁺, S, Dataset(T, C)
+    return Ŝ, T⁺, S, T, C
 end
 function marginals_and_surrogenerator(opt::OptimiseTraditional, surrogate::Surrogate, x::AbstractVector...; rng)
     emb = optimize_marginals_te(opt, x...; exclude_source = true)
     S, T, T⁺, C = individual_marginals_te(emb, x...)
     Ŝ = surrogenerator(S[:, 1], surrogate, rng)
 
-    return Ŝ, T⁺, S, Dataset(T, C)
+    return Ŝ, T⁺, S, T, C
 end
 
 function independence(test::SurrogateTest{<:TransferEntropy{<:E, <:EmbeddingTypes}}, x::AbstractVector...) where {E}
     (; measure, est, rng, surrogate, nshuffles) = test
 
     cmi = te_to_cmi(measure)
-    Ŝ, T⁺, S, TC = marginals_and_surrogenerator(measure.embedding, surrogate, x...; rng)
+    Ŝ, T⁺, S, T, C = marginals_and_surrogenerator(measure.embedding, surrogate, x...; rng)
+    TC = Dataset(T, C)
     @assert length(T⁺) == length(S) == length(TC)
     Î = estimate(cmi, est, T⁺, S, TC)
     Îs = zeros(nshuffles)
     for b in 1:nshuffles
         # TE(ŝ -> t) := I(t⁺; ŝ⁻ | t⁻, c⁻)
         Îs[b] = estimate(cmi, est, T⁺, Ŝ(), TC)
+    end
+    p = count(Î .<= Îs) / nshuffles
+
+    return SurrogateTestResult(Î, Îs, p, nshuffles)
+end
+
+function independence(test::SurrogateTest{<:TransferEntropy{<:E, <:EmbeddingTypes}, <:TransferEntropyEstimator}, x::AbstractVector...) where {E}
+    (; measure, est, rng, surrogate, nshuffles) = test
+
+    Ŝ, T⁺, S, T, C = marginals_and_surrogenerator(measure.embedding, surrogate, x...; rng)
+    @assert length(T⁺) == length(S) == length(T) == length(C)
+    Î = estimate(measure, est, S, T, T⁺, C)
+    Îs = zeros(nshuffles)
+    for b in 1:nshuffles
+        # TE(ŝ -> t) := I(t⁺; ŝ⁻ | t⁻, c⁻)
+        Îs[b] = estimate(measure, est, Dataset(Ŝ()), T, T⁺, C)
     end
     p = count(Î .<= Îs) / nshuffles
 

--- a/src/methods/infomeasures/transferentropy/TERenyiJizba.jl
+++ b/src/methods/infomeasures/transferentropy/TERenyiJizba.jl
@@ -54,18 +54,3 @@ struct TERenyiJizba{E <: Renyi, EMB} <: TransferEntropy{E, EMB}
         return new{E, EMB}(e, embedding)
     end
 end
-
-"""
-    escort_distribution(probs, i::Int, q::Real)
-
-The escort distribution for a probability distribution `probs`. For `q > 1`, the
-escort distribution emphasises more probable events and de-emphasises more improbable
-events. For `q < 1`, the situation is reversed.
-
-```math
-\\text{esc}_q(x) = \\dfrac{p^q(x)}{\\sum_{x \\in \\mathcal{X}} p^q(x)}
-```
-"""
-function escort_distribution(probs, i::Int, q)
-    return probs[i]^q / sum(probs .^ q)
-end

--- a/src/methods/infomeasures/transferentropy/TEShannon.jl
+++ b/src/methods/infomeasures/transferentropy/TEShannon.jl
@@ -58,27 +58,27 @@ struct TEShannon{E <: Shannon, EMB} <: TransferEntropy{E, EMB}
     # TODO: add constructor that automatically determines the embedding.
 end
 
-function transferentropy(
-        est::Union{
-            ConditionalMutualInformationEstimator,
-            MutualInformationEstimator,
-            DifferentialEntropyEstimator,
-            ProbabilitiesEstimator
-        },
-        x...; kwargs...)
-    N = length(first(x))
+# function transferentropy(
+#         est::Union{
+#             ConditionalMutualInformationEstimator,
+#             MutualInformationEstimator,
+#             DifferentialEntropyEstimator,
+#             ProbabilitiesEstimator
+#         },
+#         x...; kwargs...)
+#     N = length(first(x))
 
-    # A very naive heuristic to avoid too high dimensions. *All* marginals are optimised,
-    # so in the worst case, the dimension triples.
-    maxdim = floor(Int, N^(1/7))
-    # The maxlag should also scale with the length the input.
-    maxlag = min(floor(Int, N ÷ 50), 100)
-    dmethod = "mi_min"
-    method = delay_f1nn
-    opt = OptimiseTraditional(; maxdim, maxlag, method, dmethod)
-    m = TEShannon(; base = 2, embedding = EmbeddingTE(opt, x...))
-    return transferentropy(m, est, x...; kwargs...)
-end
+#     # A very naive heuristic to avoid too high dimensions. *All* marginals are optimised,
+#     # so in the worst case, the dimension triples.
+#     maxdim = floor(Int, N^(1/7))
+#     # The maxlag should also scale with the length the input.
+#     maxlag = min(floor(Int, N ÷ 50), 100)
+#     dmethod = "mi_min"
+#     method = delay_f1nn
+#     opt = OptimiseTraditional(; maxdim, maxlag, method, dmethod)
+#     m = TEShannon(; base = 2, embedding = EmbeddingTE(opt, x...))
+#     return transferentropy(m, est, x...; kwargs...)
+# end
 
 # If a pre-computed [`ContingencyMatrix`](@ref) `c` is provided, then we just compute
 # the conditional mutual information directly from it, assuming the contingency matrix

--- a/src/methods/infomeasures/transferentropy/convenience/Hilbert.jl
+++ b/src/methods/infomeasures/transferentropy/convenience/Hilbert.jl
@@ -55,7 +55,7 @@ struct Hilbert{E} <: TransferEntropyEstimator
     end
 end
 
-function transferentropy(measure::TransferEntropy, est::Hilbert, source, target)
+function estimate(measure::TransferEntropy, est::Hilbert, source, target)
     hil_s = DSP.hilbert(source)
     hil_t = DSP.hilbert(target)
 

--- a/src/methods/infomeasures/transferentropy/convenience/Hilbert.jl
+++ b/src/methods/infomeasures/transferentropy/convenience/Hilbert.jl
@@ -79,7 +79,7 @@ function estimate(measure::TransferEntropy, est::Hilbert, source, target)
     transferentropy(measure, est.est, s, t)
 end
 
-function transferentropy(measure::TransferEntropy, est::Hilbert, source, target, cond)
+function estimate(measure::TransferEntropy, est::Hilbert, source, target, cond)
     hil_s = DSP.hilbert(source)
     hil_t = DSP.hilbert(target)
     hil_c = DSP.hilbert(cond)

--- a/src/methods/infomeasures/transferentropy/convenience/SymbolicTransferEntropy.jl
+++ b/src/methods/infomeasures/transferentropy/convenience/SymbolicTransferEntropy.jl
@@ -29,7 +29,7 @@ Base.@kwdef struct SymbolicTransferEntropy <: TransferEntropyEstimator
 end
 
 
-function transferentropy(measure::TransferEntropy, est::SymbolicTransferEntropy,
+function estimate(measure::TransferEntropy, est::SymbolicTransferEntropy,
     x::AbstractVector...)
     (; m, τ, lt) = est
     est = SymbolicPermutation(; m, τ, lt)

--- a/src/methods/infomeasures/transferentropy/estimators/Lindner.jl
+++ b/src/methods/infomeasures/transferentropy/estimators/Lindner.jl
@@ -38,7 +38,7 @@ neighbor searches are performed.
     A Matlab open source toolbox to analyse information flow in time series data with
     transfer entropy. BMC neuroscience, 12(1), 1-22.
 """
-Base.@kwdef struct Lindner{B} <: DifferentialEntropyEstimator
+Base.@kwdef struct Lindner{B} <: TransferEntropyEstimator
     k::Int = 2 # number of neighbors in joint space.
     w::Int = 0
     base::B = 2
@@ -49,9 +49,26 @@ Base.@kwdef struct Lindner{B} <: DifferentialEntropyEstimator
     end
 end
 
-function transferentropy(measure::TEShannon, est::Lindner, args...)
+function estimate(measure::TEShannon, est::Lindner, x::AbstractVector...)
+    S, T, T⁺, C = individual_marginals_te(measure.embedding, x...)
+    return estimate(measure, est, S, T, T⁺, C)
+end
+
+# This method is separate from the one above because when using `SurrogateTest`,
+# `S` is repeatedly shuffled, while the other marginals are not, so we avoid
+# allocating a bunch of new datasets for every shuffle.
+function estimate(measure::TEShannon, est::Lindner,
+        S::AbstractDataset,
+        T::AbstractDataset,
+        T⁺::AbstractDataset,
+        C::AbstractDataset)
     (; k, w, base) = est
-    joint, ST, TT⁺, T = h4_marginals(measure, args...)
+
+    joint = Dataset(S, T, T⁺, C)
+    ST = Dataset(S, T, C)
+    TT⁺ = Dataset(T, T⁺, C)
+    T = Dataset(T, C)
+
     N = length(joint)
     W = Theiler(w)
     metric =  Chebyshev()

--- a/src/methods/infomeasures/transferentropy/estimators/Zhu1.jl
+++ b/src/methods/infomeasures/transferentropy/estimators/Zhu1.jl
@@ -34,7 +34,7 @@ when searching for neighbours).
     sciences, 23(3-4), 301-321.
 """
 Base.@kwdef struct Zhu1 <: TransferEntropyEstimator
-    k::Int = 1
+    k::Int = 2
     w::Int = 0
 
     function Zhu1(k::Int, w::Int)

--- a/src/methods/infomeasures/transferentropy/estimators/Zhu1.jl
+++ b/src/methods/infomeasures/transferentropy/estimators/Zhu1.jl
@@ -43,18 +43,21 @@ Base.@kwdef struct Zhu1 <: TransferEntropyEstimator
     end
 end
 
-function transferentropy(measure::TEShannon, est::Zhu1, x...)
-    (; k, w) = est
-
+function estimate(measure::TEShannon, est::Zhu1, x::AbstractVector...)
     # The Zhu1 estimator needs to keep track of the dimension of the individual
     # terms that goes into the implicit CMI computation. We could have just used
     # `h4_marginals` here, but then we wouldn't get the dimensions out of the box.
     S, T, T⁺, C = individual_marginals_te(measure.embedding, x...)
+    return estimate(measure, est, S, T, T⁺, C)
+end
+
+function estimate(measure::TEShannon, est::Zhu1, S::AbstractDataset, T::AbstractDataset, T⁺::AbstractDataset, C::AbstractDataset)
+    (; k, w) = est
+
     joint = Dataset(S, T, T⁺, C)
     ST = Dataset(S, T, C)
     TT⁺ = Dataset(T, T⁺, C)
     T = Dataset(T, C)
-
     DS = dimension(S)
     DT = dimension(T)
     DT⁺ = dimension(T⁺)
@@ -71,7 +74,9 @@ function transferentropy(measure::TEShannon, est::Zhu1, x...)
     # For each `xᵢ ∈ M`, where `M` is one of the marginal spaces, count the number of
     # points within distance `ds[i]` from the point. Then count, for each point in each
     # of the marginals, how many neighbors each `xᵢ` has given `ds[i]`.
-    tree_ST, tree_TT⁺, tree_T = KDTree.([ST, TT⁺, T], Ref(Chebyshev()))
+    tree_ST = KDTree(ST, Chebyshev())
+    tree_TT⁺ = KDTree(TT⁺, Chebyshev())
+    tree_T = KDTree(T, Chebyshev())
     nns_ST    = [isearch(tree_ST, pᵢ, WithinRange(ds[i])) for (i, pᵢ) in enumerate(ST)]
     nns_TT⁺   = [isearch(tree_TT⁺, pᵢ, WithinRange(ds[i])) for (i, pᵢ) in enumerate(TT⁺)]
     nns_T     = [isearch(tree_T, pᵢ, WithinRange(ds[i])) for (i, pᵢ) in enumerate(T)]

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -109,9 +109,11 @@ function transferentropy(measure::TransferEntropy, est, x...)
     return condmutualinfo(cmi, est, T⁺, S, Dataset(T, C))
 end
 
+# When using any estimator except dedicatd `TransferEntropyEstimator`s,
+# we use the conditional mutual information decomposition, so we need
+# to change the measure for dispatch to work.
 te_to_cmi(measure::TEShannon) = CMIShannon(measure.e)
 te_to_cmi(measure::TERenyiJizba) = CMIRenyiJizba(measure.e)
-
 
 function individual_marginals_te(emb::EmbeddingTE, x::AbstractVector...)
     joint, vars, τs, js = te_embed(emb, x...)

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -11,7 +11,7 @@ include("utils.jl")
 """
     TransferEntropy <: AssociationMeasure
 
-The supertype of all transfer entropy measures. Concrete subtypes are 
+The supertype of all transfer entropy measures. Concrete subtypes are
 - [`TEShannon`](@ref)
 - [`TERenyiJizba`](@ref)
 """
@@ -96,10 +96,10 @@ function transferentropy(measure::TransferEntropy, est, x...)
     # dataset. The horizontal concatenation of C with T then just returns T.
     # We therefore don't need separate methods for the conditional and non-conditional
     # cases.
-    S, T, Tf, C = individual_marginals_te(measure.embedding, x...)
+    S, T, T⁺, C = individual_marginals_te(measure.embedding, x...)
     cmi = te_to_cmi(measure)
     # TE(s -> t) := I(t⁺; s⁻ | t⁻, c⁻).
-    return condmutualinfo(cmi, est, Tf, S, Dataset(T, C))
+    return condmutualinfo(cmi, est, T⁺, S, Dataset(T, C))
 end
 
 te_to_cmi(measure::TEShannon) = CMIShannon(measure.e)

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -98,7 +98,7 @@ function estimate(est::TE_ESTIMATORS, args...; kwargs...)
     estimate(TEShannon(), est, args...; kwargs...)
 end
 
-function transferentropy(measure::TransferEntropy, est, x...)
+function estimate(measure::TransferEntropy, est::TE_ESTIMATORS, x...)
     # If a conditional input (x[3]) is not provided, then C is just a 0-dimensional
     # dataset. The horizontal concatenation of C with T then just returns T.
     # We therefore don't need separate methods for the conditional and non-conditional

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -90,6 +90,9 @@ include("optimization/optimization.jl")
 include("TEShannon.jl")
 include("TERenyiJizba.jl")
 
+function transferentropy(args...; kwargs...)
+    return estimate(args...; kwargs...)
+end
 
 function transferentropy(measure::TransferEntropy, est, x...)
     # If a conditional input (x[3]) is not provided, then C is just a 0-dimensional
@@ -128,8 +131,8 @@ include("estimators/estimators.jl")
 include("convenience/convenience.jl")
 
 # Default to Shannon-type base 2 transfer entropy
-function transferentropy(est::TransferEntropyEstimator, x...)
-    transferentropy(TEShannon(base = 2), est, x...)
+function estimate(est::TransferEntropyEstimator, x...)
+    estimate(TEShannon(base = 2), est, x...)
 end
 
 transferentropy(emb::EmbeddingTE, args...; kwargs...) =

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -94,6 +94,10 @@ function transferentropy(args...; kwargs...)
     return estimate(args...; kwargs...)
 end
 
+function estimate(est::TE_ESTIMATORS, args...; kwargs...)
+    estimate(TEShannon(), est, args...; kwargs...)
+end
+
 function transferentropy(measure::TransferEntropy, est, x...)
     # If a conditional input (x[3]) is not provided, then C is just a 0-dimensional
     # dataset. The horizontal concatenation of C with T then just returns T.

--- a/test/independence/SurrogateTest/TransferEntropyConditional.jl
+++ b/test/independence/SurrogateTest/TransferEntropyConditional.jl
@@ -1,9 +1,9 @@
-# A chain of coupled logistic maps. Set the coupling from first to second 
+# A chain of coupled logistic maps. Set the coupling from first to second
 # variable high, so that transferentropy(x → z) becomes significant.
 # This should vanish when doing transferentropy(x → z | y)
-sys = logistic4(c₁₂ = 0.6, u₀ = [0.1, 0.2, 0.3, 0.4]);
-n = 2000
-x, y,z, w = columns(trajectory(sys, n, Ttr = 10000));
+sys = system(Logistic4Chain(xi = [0.1, 0.2, 0.3, 0.4]));
+n = 500
+x, y, z, w = columns(trajectory(sys, n, Ttr = 10000));
 
 α = 0.04 # Arbitrary significance level 1 - α = 0.96
 
@@ -15,3 +15,6 @@ test = SurrogateTest(TEShannon(), FPVP())
 
 # We should be able to reject the null when testing transferentropy(x → y | z)
 @test pvalue(independence(test, x, z, y)) > α
+
+@test independence(SurrogateTest(TEShannon(), Zhu1()), x, y, z) isa SurrogateTestResult
+@test independence(SurrogateTest(TEShannon(), Lindner()), x, y, z) isa SurrogateTestResult

--- a/test/independence/SurrogateTest/TransferEntropyPairwise.jl
+++ b/test/independence/SurrogateTest/TransferEntropyPairwise.jl
@@ -1,5 +1,5 @@
-sys = logistic2_unidir(c_xy = 0.5)
-x, y = columns(trajectory(sys, 3000, Ttr = 10000))
+sys = system(Logistic2Unidir(c_xy = 0.5))
+x, y = columns(trajectory(sys, 1000, Ttr = 10000))
 
 # ArgumentError thrown if an estimator isn't provided.
 @test_throws ArgumentError SurrogateTest(TEShannon())
@@ -15,3 +15,7 @@ test = SurrogateTest(TEShannon(), FPVP())
 # The ground truth is X → Y, so we shouldn't be able to reject the null
 # when testing transferentropy(y → x)
 @test pvalue(independence(test, y, x)) > α
+
+x, y = columns(trajectory(sys, 100, Ttr = 1000))
+@test independence(SurrogateTest(TEShannon(), Lindner()), x, y) isa SurrogateTestResult
+@test independence(SurrogateTest(TEShannon(), Zhu1()), x, y) isa SurrogateTestResult

--- a/test/methods/infomeasures/transferentropy.jl
+++ b/test/methods/infomeasures/transferentropy.jl
@@ -3,7 +3,8 @@ x, y, z = rand(1000), rand(1000), rand(1000)
 est = Lindner( k = 5)
 @test transferentropy(est, x, y) isa Real
 
-est = Zhu1( k = 5)
+est = Zhu1(k = 5)
+@test_throws DomainError Zhu1(k = 1)
 @test transferentropy(est, x, y) isa Real
 
 est = ZhuSingh(k = 5)


### PR DESCRIPTION
- Reorganised method signatures, so that surrogate realisations of the source embedding can be passed. Before, it was only possible to pass time series.
- Fixes #240 
- Fixes #243 
- Fixes #245