### PR TITLE
Fix OCE bug that occurs when no pairwise associations are found

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -100,28 +100,31 @@ function select_parents(alg::OCE, τs, js, 𝒫s, x, i::Int; verbose = false)
     ###################################################################
     # 1. Can we find a significant pairwise association?
     significant_pairwise = select_first_parent!(parents, idxs_remaining, alg, τs, js, 𝒫s, xᵢ; verbose)
-    # 2. Continue until there are no more significant conditional pairwise associations
-    significant_cond = true
-    k = 0
-    verbose && println("Conditional tests")
-    while significant_cond
-        k += 1
-        significant_cond = select_conditional_parent!(parents, idxs_remaining, alg, τs, js, 𝒫s, xᵢ; verbose)
-    end
 
-    ###################################################################
-    # Backward elimination
-    ###################################################################
-    bw_significant = true
-    k = 0
-    M = length(parents.parents)
-    verbose && println("Backwards elimination")
-    k = 1
-    while length(parents.parents) >= 1 && k < length(parents.parents)
-        verbose && println("\tk=$k, length(parents) = $(length(parents.parents))")
-        bw_significant = backwards_eliminate!(parents, alg, xᵢ, k; verbose)
-        if bw_significant
+    if significant_pairwise
+        # 2. Continue until there are no more significant conditional pairwise associations
+        significant_cond = true
+        k = 0
+        verbose && println("Conditional tests")
+        while significant_cond
             k += 1
+            significant_cond = select_conditional_parent!(parents, idxs_remaining, alg, τs, js, 𝒫s, xᵢ; verbose)
+        end
+
+        ###################################################################
+        # Backward elimination
+        ###################################################################
+        bw_significant = true
+        k = 0
+        M = length(parents.parents)
+        verbose && println("Backwards elimination")
+        k = 1
+        while length(parents.parents) >= 1 && k < length(parents.parents)
+            verbose && println("\tk=$k, length(parents) = $(length(parents.parents))")
+            bw_significant = backwards_eliminate!(parents, alg, xᵢ, k; verbose)
+            if bw_significant
+                k += 1
+            end
         end
     end
     return parents
@@ -163,6 +166,7 @@ end
 
 function select_conditional_parent!(parents, idxs_remaining, alg, τs, js, 𝒫s, xᵢ; verbose)
     P = StateSpaceSet(parents.parents...)
+
     M = length(𝒫s)
     Is = zeros(M)
     pvals = zeros(M)


### PR DESCRIPTION
- Fixes #264 

`select_first_parent!` returns a boolean indicating whether a significant pairwise association was found. With this fix, this boolean is actually used to check whether conditional testing is required.