### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -53,6 +53,6 @@ SpecialFunctions = "2"
 StateSpaceSets = "^1.1"
 StaticArrays = "^1"
 StatsBase = "^0.33"
-TimeseriesSurrogates = "^2"
+TimeseriesSurrogates = "~2.1"
 Wavelets = "0.9"
 julia = "^1.6"


### PR DESCRIPTION
This PR bumps the patch version and locks TimeseriesSurrogates.jl to v2.1, so that we can merge https://github.com/JuliaDynamics/TimeseriesSurrogates.jl/pull/143 and release TimeseriesSurrogates v2.2 without conflict between `TimeseriesSurrogates.SurrogateTest` and `CausalityTools.SurrogateTest`. 