### PR TITLE
OCE efficiency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -36,7 +36,7 @@ Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 [compat]
 Accessors = "^0.1.28"
 Combinatorics = "1"
-ComplexityMeasures = "^2.6" # contains important bugfix
+ComplexityMeasures = "^2.6"
 DSP = "0.7"
 DelayEmbeddings = "2.6"
 Distances = "^0.10"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.3.0
+
+- Significant speed-ups for `OCE` by sorting on maximal measure, thus avoiding
+    unnecessary significance tests.
+- Default parameters for `OCE` default lag parameter have changed. Now, `τmax = 1`, since
+    that is the only case considered in the original paper. We also use the
+    `MesnerShalisi` CMI estimator for the conditional step, because in contrast to
+    the `FPVP` estimator, it has been shown to be consistent.
+- Source code for `OCE` has been drastically simplified by merging the pairwise
+    and conditional parent finding steps.
+- `OCE` result can now be converted to a `SimpleDiGraph` from Graphs.jl.
+
 ## 2.2.1
 
 - `infer_graph` now accepts the `verbose` keyword.

--- a/docs/src/examples/examples_graphs.md
+++ b/docs/src/examples/examples_graphs.md
@@ -8,6 +8,7 @@ for the conditional steps.
 
 ```@example causalgraph_oce
 using CausalityTools
+using Graphs
 using Random
 rng = MersenneTwister(1234)
 
@@ -21,7 +22,11 @@ ctest = LocalPermutationTest(CMIShannon(), FPVP(k = 5))
 
 # Infer graph
 alg = OCE(; utest, ctest, α = 0.05, τmax = 3)
-infer_graph(alg, [x, y, z, w])
+parents = infer_graph(alg, [x, y, z, w])
+
+# Convert to graph and inspect edges
+g = SimpleDiGraph(parents)
+collect(edges(g))
 ```
 
 The algorithm nicely recovers the true causal directions.

--- a/docs/src/examples/examples_graphs.md
+++ b/docs/src/examples/examples_graphs.md
@@ -17,11 +17,11 @@ sys = system(Logistic4Chain(; rng))
 x, y, z, w = columns(trajectory(sys, 400, Ttr = 10000))
 
 # Independence tests for unconditional and conditional stages.
-utest = SurrogateTest(MIShannon(), KSG2(k = 5))
-ctest = LocalPermutationTest(CMIShannon(), FPVP(k = 5))
+utest = SurrogateTest(MIShannon(), KSG2(k = 3, w = 1); rng, nshuffles = 150)
+ctest = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 3, w = 1); rng, nshuffles = 150)
 
 # Infer graph
-alg = OCE(; utest, ctest, α = 0.05, τmax = 3)
+alg = OCE(; utest, ctest, α = 0.05, τmax = 1)
 parents = infer_graph(alg, [x, y, z, w])
 
 # Convert to graph and inspect edges

--- a/src/CausalityTools.jl
+++ b/src/CausalityTools.jl
@@ -56,28 +56,19 @@ module CausalityTools
     # Update messages:
     using Scratch
     display_update = true
-    version_number = "2.0.0"
+    version_number = "2.3.0"
     update_name = "update_v$(version_number)"
     update_message = """
     \nUpdate message: CausalityTools v$(version_number)\n
-    - An overall overhaul of the API and documentation. See the online documentation
-        for a full overview.
-    - There are now three conceptual levels of funcationality: 1) association measures,
-        2) independence testing based on these measures, and 3) causal graph inference.
-
-    Other changes:
-    - A plethora of new methods and estimators for information theoretic quantities have
-        been added. See the online documentation for an overview.
-    - Syntax for many methods have changed. Estimators, which
-        also contains analysis parameters, are now always the first argument.
-    - All information-based methods in the DynamicalSystems.jl organization that are
-        more complex than those in `ComplexityMeasures.jl` have been moved to CausalityTools.jl.
-        This include `mutualinfo`, `condmutualinfo` and `transferentropy`.
-    - TransferEntropy.jl has been discontinued, and all its functionality has been moved to
-        CausalityTools.jl. `conditional_mutualinfo` has been renamed to `condmutualinfo`.
-    - The `Kraskov1` and `Kraskov2` mutual information estimators have been renamed to
-        `KraskovStögbauerGrassberger1` (`KSG1` for short) and
-        `KraskovStögbauerGrassberger2` (`KSG2` for short).
+    - Significant speed-ups for `OCE` by sorting on maximal measure, thus avoiding
+    unnecessary significance tests.
+    - Default parameters for `OCE` default lag parameter have changed. Now, `τmax = 1`, since
+        that is the only case considered in the original paper. We also use the
+        `MesnerShalisi` CMI estimator for the conditional step, because in contrast to
+        the `FPVP` estimator, it has been shown to be consistent.
+    - Source code for `OCE` has been drastically simplified by merging the pairwise
+        and conditional parent finding steps.
+    - `OCE` result can now be converted to a `SimpleDiGraph` from Graphs.jl.
     """
 
     if display_update

--- a/src/causal_graphs/causal_graphs.jl
+++ b/src/causal_graphs/causal_graphs.jl
@@ -1,3 +1,8 @@
+import Graphs.SimpleGraphs: SimpleDiGraph
+import Graphs: edges
+export SimpleDiGraph
+export edges
+
 include("api.jl")
 
 # Concrete implementations

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -105,6 +105,10 @@ function SimpleDiGraph(v::Vector{<:CausalityTools.OCESelectedParents})
     end
     return g
 end
+
+function select_parents(alg::OCE, x, i::Int; verbose = false)
+    τs, js, 𝒫s = prepare_embeddings(alg, x, i)
+
     verbose && println("\nInferring parents for x$i(0)...")
     # Account for the fact that the `𝒫ⱼ ∈ 𝒫s` are embedded. This means that some points are
     # lost from the `xᵢ`s.

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -134,25 +134,11 @@ function select_parents(alg::OCE, x, i::Int; verbose = false)
         ###################################################################
         # Backward elimination
         ###################################################################
-        if !(length(parents.parents) >= 2)
-            return parents
-        end
-
-        verbose && println("˧ Backwards elimination...")
-
-        eliminate = true
-        ks_remaining = Set(1:length(parents.parents))
-        while eliminate && length(ks_remaining) >= 2
-            for k in ks_remaining
-                eliminate = backwards_eliminate!(parents, alg, xᵢ, k; verbose)
-                if eliminate
-                    filter!(x -> x == k, ks_remaining)
-                end
-            end
-        end
+        backwards_eliminate!(alg, parents, xᵢ, i; verbose)
     end
     return parents
 end
+
 
 function prepare_embeddings(alg::OCE, x, i)
     # Preliminary parents

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -41,9 +41,9 @@ graph with all the detected associations.
     causation entropy. SIAM Journal on Applied Dynamical Systems, 14(1), 73-106.
 """
 Base.@kwdef struct OCE{U, C, T} <: GraphAlgorithm
-    utest::U = SurrogateTest(MIShannon(), KSG2(k = 3, w = 3))
-    ctest::C = LocalPermutationTest(CMIShannon(), FPVP(k = 3, w = 3))
-    τmax::T = 5
+    utest::U = SurrogateTest(MIShannon(), KSG2(k = 3, w = 3), nshuffles = 100)
+    ctest::C = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 3, w = 3), nshuffles = 100)
+    τmax::T = 1
     α = 0.05
 end
 

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -31,8 +31,8 @@ its potential parents `xⱼ(-τ)`. Sun et al. 2015's method is based on `τmax =
 ## Returns
 
 When used with [`infer_graph`](@ref), it returns a vector `p`, where `p[i]` are the
-parents for each input variable. In the future, this will return a labelled, directed
-graph with all the detected associations.
+parents for each input variable. This result can be converted to a `SimpleDiGraph`
+from Graphs.jl (see [example](@ref oce_example)).
 
 ## Examples
 

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -47,8 +47,8 @@ Base.@kwdef struct OCE{U, C, T} <: GraphAlgorithm
 end
 
 function infer_graph(alg::OCE, x; verbose = true)
-    parents = select_parents(alg, x; verbose)
-    return parents
+    return select_parents(alg, x; verbose)
+end
 end
 
 """

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -63,17 +63,8 @@ parents of each `xᵢ ∈ x`, assuming that `x` must be integer-indexable, i.e.
 """
 function select_parents(alg::OCE, x; verbose = false)
 
-    # Preliminary parents
-    τs = Iterators.flatten([-1:-1:-alg.τmax |> collect for xᵢ in x]) |> collect
-    js = Iterators.flatten([fill(i, alg.τmax) for i in eachindex(x)]) |> collect
-    embeddings = [genembed(xᵢ, -1:-1:-alg.τmax) for xᵢ in x]
-    T = typeof(1.0)
-    𝒫s = Vector{Vector{T}}(undef, 0)
-    for emb in embeddings
-        append!(𝒫s, columns(emb))
-    end
     # Find the parents of each variable.
-    parents = [select_parents(alg, τs, js, 𝒫s, x, k; verbose) for k in eachindex(x)]
+    parents = [select_parents(alg, x, k; verbose) for k in eachindex(x)]
     return parents
 end
 

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -3,9 +3,8 @@ export OCE
 """
     OCE <: GraphAlgorithm
     OCE(; utest::IndependenceTest = SurrogateTest(MIShannon(), KSG2(k = 3, w = 3)),
-          ctest::C = LocalPermutationTest(CMIShannon(), FPVP(k = 3, w = 3)),
-          τmax::T = 5, α = 0.05
-    )
+          ctest::C = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 3, w = 3)),
+          τmax::T = 1, α = 0.05)
 
 The optimal causation entropy (OCE) algorithm for causal discovery (Sun et al.,
 2015)[^Sun2015].
@@ -24,7 +23,7 @@ The OCE algorithm has three steps to determine the parents of a variable `xᵢ`.
     where `P` is the set of parent nodes found in the previous steps.
 
 `τmax` indicates the maximum lag `τ` between the target variable `xᵢ(0)` and
-its potential parents `xⱼ(-τ)`.
+its potential parents `xⱼ(-τ)`. Sun et al. 2015's method is based on `τmax = 1`.
 
 ## Returns
 

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -1,3 +1,6 @@
+using Graphs: add_edge!
+using Graphs.SimpleGraphs: SimpleDiGraph
+
 export OCE
 
 """
@@ -89,7 +92,19 @@ function Base.show(io::IO, x::OCESelectedParents)
     show(io, all)
 end
 
-function select_parents(alg::OCE, τs, js, 𝒫s, x, i::Int; verbose = false)
+function SimpleDiGraph(v::Vector{<:CausalityTools.OCESelectedParents})
+    N = length(v)
+    g = SimpleDiGraph(N)
+    for k = 1:N
+        parents = v[k]
+        for (j, τ) in zip(parents.parents_js, parents.parents_τs)
+            if j != k # avoid self-loops
+                add_edge!(g, j, k)
+            end
+        end
+    end
+    return g
+end
     verbose && println("\nInferring parents for x$i(0)...")
     # Account for the fact that the `𝒫ⱼ ∈ 𝒫s` are embedded. This means that some points are
     # lost from the `xᵢ`s.

--- a/src/causal_graphs/oce/OCE.jl
+++ b/src/causal_graphs/oce/OCE.jl
@@ -49,6 +49,9 @@ end
 function infer_graph(alg::OCE, x; verbose = true)
     return select_parents(alg, x; verbose)
 end
+
+function infer_graph(alg::OCE, x::AbstractDataset; verbose = true)
+    return infer_graph(alg, columns(x); verbose)
 end
 
 """

--- a/test/causal_graphs/oce.jl
+++ b/test/causal_graphs/oce.jl
@@ -15,21 +15,20 @@ parents = infer_graph(alg, X; verbose = true)
 @test SimpleDiGraph(parents) isa SimpleDiGraph
 
 rng = StableRNG(123)
-sys = system(CommonCauseMutual(; rng))
-X = columns(trajectory(sys, 200, Ttr = 10000))
+sys = system(Logistic2Bidir(; rng))
+X = columns(trajectory(sys, 300, Ttr = 10000))
 utest = SurrogateTest(MIShannon(), KSG1(k = 10, w = 1); rng, nshuffles = 100)
 ctest = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 10, w = 1); rng, nshuffles = 100)
 parents = infer_graph(OCE(; utest, ctest, τmax = 1), X; verbose = true)
 @test parents isa Vector{<:OCESelectedParents}
 g = SimpleDiGraph(parents)
 @test g isa SimpleDiGraph
+
 # "Analytical" test: check that we at least identify one true positive. There may
 # be several false positives, but there's no way of telling a priori how many.
-function at_least_one_true_positive(sys, estimated_graph)
+function at_least_one_true_positive(true_edges, estimated_graph)
     estimated_edges = edges(estimated_graph)
-    true_edges = edges(SimpleDiGraph(sys))
     at_least_one_tp = false
-
     for e in true_edges
         if e in estimated_edges
             at_least_one_tp = true
@@ -38,4 +37,4 @@ function at_least_one_true_positive(sys, estimated_graph)
     return at_least_one_tp
 end
 
-@test at_least_one_true_positive(CommonCauseMutual(), g)
+@test at_least_one_true_positive([SimpleEdge(1, 2), SimpleEdge(2, 1)], g)

--- a/test/causal_graphs/oce.jl
+++ b/test/causal_graphs/oce.jl
@@ -1,15 +1,41 @@
 using CausalityTools
+using CausalityTools: OCESelectedParents
 using Test
 using StableRNGs
+using Graphs.SimpleGraphs: SimpleEdge
 
 rng = StableRNG(123)
 sys = system(Logistic4Chain(; rng))
-X = columns(trajectory(sys, 350, Ttr = 10000))
+X = columns(trajectory(sys, 60, Ttr = 10000))
+utest = SurrogateTest(MIShannon(), KSG1(k = 10, w = 1); rng, nshuffles = 30)
+ctest = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 10, w = 1); rng, nshuffles = 30)
+alg = OCE(; utest, ctest, τmax = 2)
+parents = infer_graph(alg, X; verbose = true)
+@test parents isa Vector{<:OCESelectedParents}
+@test SimpleDiGraph(parents) isa SimpleDiGraph
 
-parents = infer_graph(OCE(τmax = 2), X)
-@test all(x ∉ parents[1].parents_js for x in (2, 3, 4))
-@test all(x ∉ parents[2].parents_js for x in (3, 4))
-@test all(x ∉ parents[3].parents_js for x in (4))
-@test 1 ∈ parents[2].parents_js
-@test 2 ∈ parents[3].parents_js
-@test 3 ∈ parents[4].parents_js
+rng = StableRNG(123)
+sys = system(CommonCauseMutual(; rng))
+X = columns(trajectory(sys, 200, Ttr = 10000))
+utest = SurrogateTest(MIShannon(), KSG1(k = 10, w = 1); rng, nshuffles = 100)
+ctest = LocalPermutationTest(CMIShannon(), MesnerShalisi(k = 10, w = 1); rng, nshuffles = 100)
+parents = infer_graph(OCE(; utest, ctest, τmax = 1), X; verbose = true)
+@test parents isa Vector{<:OCESelectedParents}
+g = SimpleDiGraph(parents)
+@test g isa SimpleDiGraph
+# "Analytical" test: check that we at least identify one true positive. There may
+# be several false positives, but there's no way of telling a priori how many.
+function at_least_one_true_positive(sys, estimated_graph)
+    estimated_edges = edges(estimated_graph)
+    true_edges = edges(SimpleDiGraph(sys))
+    at_least_one_tp = false
+
+    for e in true_edges
+        if e in estimated_edges
+            at_least_one_tp = true
+        end
+    end
+    return at_least_one_tp
+end
+
+@test at_least_one_true_positive(CommonCauseMutual(), g)


### PR DESCRIPTION
- Simplify source code for `OCE`
- Drastically reduce the runtime of the `OCE` algorithm by sorting on maximum measure _before_ independence tests are applied.  Fixes #287.
- It is now possible to call `SimpleDiGraph` on the result of `infer_graph(OCE(), X)`, which returns a directed graph.
- Related: reexport some basic functions/types from Graphs.jl.
