### PR TITLE
Partial distance correlation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.3.1"
+version = "2.4.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - Added partial distance correlation measure. To compute it, simply provide a
     third input argument to `distance_correlation`.
+- `DistanceCorrelation` is now compatible with both `SurrogateTest` and
+    `LocalPermutationTest` in its conditional form.
 
 ## 2.3.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.0
+
+- Added partial distance correlation measure. To compute it, simply provide a
+    third input argument to `distance_correlation`.
+
 ## 2.3.1
 
 - The `MesnerShalisi` estimator is now deprecated and renamed to `MesnerShalizi` (with

--- a/docs/src/measures.md
+++ b/docs/src/measures.md
@@ -5,7 +5,7 @@
 | Type                   | Measure                               | Pairwise | Conditional | Function version               |
 | ---------------------- | ------------------------------------- | :------: | :---------: | ------------------------------ |
 | Correlation            | [`PearsonCorrelation`](@ref)          |    ✓    |     ✖      | [`pearson_correlation`](@ref)  |
-| Correlation            | [`DistanceCorrelation`](@ref)         |    ✓    |     ✖      | [`distance_correlation`](@ref) |
+| Correlation            | [`DistanceCorrelation`](@ref)         |    ✓    |     ✓      | [`distance_correlation`](@ref) |
 | Closeness              | [`SMeasure`](@ref)                    |    ✓    |     ✖      | [`s_measure`](@ref)            |
 | Closeness              | [`HMeasure`](@ref)                    |    ✓    |     ✖      | [`h_measure`](@ref)            |
 | Closeness              | [`MMeasure`](@ref)                    |    ✓    |     ✖      | [`m_measure`](@ref)            |

--- a/src/CausalityTools.jl
+++ b/src/CausalityTools.jl
@@ -56,12 +56,12 @@ module CausalityTools
     # Update messages:
     using Scratch
     display_update = true
-    version_number = "2.3.1"
+    version_number = "2.4.0"
     update_name = "update_v$(version_number)"
     update_message = """
     \nUpdate message: CausalityTools v$(version_number)\n
-    - The `MesnerShalisi` estimator is now deprecated and renamed to `MesnerShalizi` (with
-    correct spelling).
+    - Added partial distance correlation measure. To compute it, simply provide a
+        third input argument to `distance_correlation`.
     """
 
     if display_update

--- a/src/CausalityTools.jl
+++ b/src/CausalityTools.jl
@@ -62,6 +62,8 @@ module CausalityTools
     \nUpdate message: CausalityTools v$(version_number)\n
     - Added partial distance correlation measure. To compute it, simply provide a
         third input argument to `distance_correlation`.
+    - `DistanceCorrelation` is now compatible with both `SurrogateTest` and
+        `LocalPermutationTest` in its conditional form.
     """
 
     if display_update

--- a/src/independence_tests/local_permutation/LocalPermutationTest.jl
+++ b/src/independence_tests/local_permutation/LocalPermutationTest.jl
@@ -72,12 +72,12 @@ instead of `Z` and we `I(X; Y)` and `Iₖ(X̂; Y)` instead of `I(X; Y | Z)` and
 
 ## Compatible measures
 
-| Measure                      |       Pairwise       | Conditional | Requires `est` |
-| ---------------------------- | :------------------: | :---------: | :------------: |
-| [`PartialCorrelation`](@ref) |          ✖           |     ✓       |      No        |
-| [`CMIShannon`](@ref)         |          ✖           |     ✓       |      Yes       |
-| [`TEShannon`](@ref)          |          ✓           |     ✓       |      Yes       |
-
+| Measure                       | Pairwise | Conditional | Requires `est` |
+| ----------------------------- | :------: | :---------: | :------------: |
+| [`PartialCorrelation`](@ref)  |    ✖    |     ✓      |       No       |
+| [`DistanceCorrelation`](@ref) |    ✖    |     ✓      |       No       |
+| [`CMIShannon`](@ref)          |    ✖    |     ✓      |      Yes       |
+| [`TEShannon`](@ref)           |    ✓    |     ✓      |      Yes       |
 
 The `LocalPermutationTest` is only defined for conditional independence testing.
 Exceptions are for measures like [`TEShannon`](@ref), which use conditional

--- a/src/independence_tests/surrogate/SurrogateTest.jl
+++ b/src/independence_tests/surrogate/SurrogateTest.jl
@@ -39,7 +39,7 @@ The shuffled variable is always the first variable (`X`). Exceptions are:
 | Measure                               | Pairwise | Conditional | Requires `est` |
 | ------------------------------------- | :------: | :---------: | :------------: |
 | [`PearsonCorrelation`](@ref)          |    ✓    |     ✖      |       No       |
-| [`DistanceCorrelation`](@ref)         |    ✓    |     ✖      |       No       |
+| [`DistanceCorrelation`](@ref)         |    ✓    |     ✓      |       No       |
 | [`SMeasure`](@ref)                    |    ✓    |     ✖      |       No       |
 | [`HMeasure`](@ref)                    |    ✓    |     ✖      |       No       |
 | [`MMeasure`](@ref)                    |    ✓    |     ✖      |       No       |

--- a/src/methods/correlation/distance_correlation.jl
+++ b/src/methods/correlation/distance_correlation.jl
@@ -36,14 +36,20 @@ struct DistanceCorrelation <: AssociationMeasure end
 
 """
     distance_correlation(x, y) → dcor ∈ [0, 1]
-    distance_correlation(x, y, z) → pdcor ∈ [0, 1]
+    distance_correlation(x, y, z) → pdcor
 
 Compute the empirical/sample distance correlation (Székely et al., 2007)[^Székely2007],
-here called `dcor`, between StateSpaceSets `x` and `y`.
+here called `dcor`, between StateSpaceSets `x` and `y`. Alternatively, compute the
+partial distance correlation `pdcor` (Székely and Rizzo, 2014)[^Székely2014].
+
+See also: [`DistanceCorrelation`](@ref).
 
 [^Székely2007]:
     Székely, G. J., Rizzo, M. L., & Bakirov, N. K. (2007). Measuring and testing
     dependence by correlation of distances. The annals of statistics, 35(6), 2769-2794.
+[^Székely2014]:
+    Székely, G. J., & Rizzo, M. L. (2014). Partial distance correlation with methods for
+    dissimilarities.
 """
 function distance_correlation(x::ArrayOrStateSpaceSet, y::ArrayOrStateSpaceSet)
     return estimate(DistanceCorrelation(), x, y)

--- a/src/methods/correlation/distance_correlation.jl
+++ b/src/methods/correlation/distance_correlation.jl
@@ -21,7 +21,7 @@ is computed.
     coefficient.
 
 !!! warn
-    A partial distance correlation `I = distance_correlation(X, Y, Z)` doesn't
+    A partial distance correlation `distance_correlation(X, Y, Z) = 0` doesn't
     always guarantee conditional independence `X ⫫ Y | Z`. See Székely and Rizzo (2014)
     for in-depth discussion.
 
@@ -77,9 +77,11 @@ end
 
 """
     distance_covariance(x, y) → dcov::Real
+    distance_covariance(x, y, z) → pdcov::Real
 
 Compute the empirical/sample distance covariance (Székely et al., 2007)[^Székely2007]
-between StateSpaceSets `x` and `y`.
+between StateSpaceSets `x` and `y`. Alternatively, compute the partial distance
+covariance `pdcov`.
 
 [^Székely2007]:
     Székely, G. J., Rizzo, M. L., & Bakirov, N. K. (2007). Measuring and testing

--- a/src/methods/correlation/distance_correlation.jl
+++ b/src/methods/correlation/distance_correlation.jl
@@ -177,7 +177,7 @@ function distance_covariance(X::ArrayOrStateSpaceSet, Y::ArrayOrStateSpaceSet, Z
     Lx, Ly, Lz = length(X), length(Y), length(Z)
     Lx == Ly == Lz || throw(ArgumentError("Input X, Y and Z must have same lengths."))
     N = Lx
-    N >= 4 || throw(ArgumentError("Partial distance correlation is defined for 4 or more points. Got $N"))
+    N >= 4 || throw(ArgumentError("Partial distance covariance is defined for 4 or more points. Got $N"))
 
     Xds = pairwise(Euclidean(), StateSpaceSet(X))
     Yds = pairwise(Euclidean(), StateSpaceSet(Y))

--- a/src/methods/correlation/distance_correlation.jl
+++ b/src/methods/correlation/distance_correlation.jl
@@ -60,6 +60,10 @@ function distance_correlation(x::ArrayOrStateSpaceSet, y::ArrayOrStateSpaceSet,
     return estimate(DistanceCorrelation(), x, y, z)
 end
 
+function estimate(m::DistanceCorrelation, est::Nothing, args...)
+    return estimate(m, args...)
+end
+
 # Common interface for higher-level methods.
 function estimate(measure::DistanceCorrelation, X, Y)
     # TODO: Future optimization: this could be quicker if we only compute distances once

--- a/test/methods/correlation/distance_correlation.jl
+++ b/test/methods/correlation/distance_correlation.jl
@@ -11,5 +11,19 @@ v = rand(1000, 3); w = 0.5 .* v .+ 1.2;
 # Comparison with `energy` R package, which is by the authors of the original paper
 x = -1.0:0.1:1.0 |> collect
 y = map(xᵢ -> xᵢ^3 - 2xᵢ^2 - 3, x)
+z = map(yᵢ -> yᵢ^2 - 2yᵢ, y)
 dcov = distance_correlation(x, y)
 @test round(dcov, digits = 3) == 0.673
+
+# ----------------------------
+# Partial distance correlation
+# ----------------------------
+# Test internals by checking that we get the same answer as in the R `energy` package.
+M = reshape([0.0, 0.2, 0.3, 0.2, 0.0, 0.6, 0.3, 0.6, 0.3], 3, 3)
+@test CausalityTools.ucenter(M) ≈
+    [0 0.15 -0.15;
+    0.15 0.0 -0.15;
+    -0.15 -0.15 0.0]
+
+@test round(distance_correlation(x, z, y), digits = 5) ≈ round(0.1556139, digits = 5)
+@test round(CausalityTools.distance_covariance(x, z, y), digits = 5) ≈ round(0.02379782, digits = 5)


### PR DESCRIPTION
Fixes #252, but doesn't implement a new type. Simply extends `DistanceCorrelation` and related methods to three arguments.