### PR TITLE
Fix `inrangecount` warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.7.0"
+version = "2.7.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.1
+
+- Fixed an import warning.
+
 ## 2.7.0
 
 - New association measure: `PMI` (part mutual information).

--- a/src/CausalityTools.jl
+++ b/src/CausalityTools.jl
@@ -56,11 +56,12 @@ module CausalityTools
     # Update messages:
     using Scratch
     display_update = true
-    version_number = "2.7.0"
+    version_number = "2.7.1"
     update_name = "update_v$(version_number)"
     update_message = """
     \nUpdate message: CausalityTools v$(version_number)\n
     - New association measure: `PMI` (part mutual information).
+    - Fixed an import warning.
     """
 
     if display_update

--- a/src/methods/closeness/HMeasure.jl
+++ b/src/methods/closeness/HMeasure.jl
@@ -1,5 +1,9 @@
-using NearestNeighbors, Distances, Neighborhood, DelayEmbeddings
+using Neighborhood: searchstructure, bulkisearch
+using Neighborhood: NeighborNumber, Theiler
+using StateSpaceSets: AbstractStateSpaceSet
 using Distances: SqEuclidean, Euclidean
+using Distances: pairwise, evaluate
+
 export h_measure
 export HMeasure
 

--- a/src/methods/closeness/LMeasure.jl
+++ b/src/methods/closeness/LMeasure.jl
@@ -1,5 +1,8 @@
-using NearestNeighbors, Distances, Neighborhood, StateSpaceSets
+using Neighborhood: searchstructure, bulkisearch
+using Neighborhood: NeighborNumber, Theiler
+using StateSpaceSets: AbstractStateSpaceSet
 using Distances: SqEuclidean, Euclidean
+using Distances: pairwise, evaluate
 
 export LMeasure
 export l_measure

--- a/src/methods/closeness/MMeasure.jl
+++ b/src/methods/closeness/MMeasure.jl
@@ -1,5 +1,9 @@
-using NearestNeighbors, Distances, Neighborhood, DelayEmbeddings
+using Neighborhood: searchstructure, bulkisearch
+using Neighborhood: NeighborNumber, Theiler
+using StateSpaceSets: AbstractStateSpaceSet
 using Distances: SqEuclidean, Euclidean
+using Distances: pairwise, evaluate
+
 export m_measure
 export MMeasure
 

--- a/src/methods/closeness/SMeasure.jl
+++ b/src/methods/closeness/SMeasure.jl
@@ -1,5 +1,8 @@
-using NearestNeighbors, Distances, Neighborhood, DelayEmbeddings
+using Neighborhood: searchstructure, bulkisearch
+using Neighborhood: NeighborNumber, Theiler
+using StateSpaceSets: AbstractStateSpaceSet
 using Distances: SqEuclidean, Euclidean
+using Distances: pairwise, evaluate
 
 export SMeasure
 export s_measure


### PR DESCRIPTION
There's a conflicting import of `inrangecount` from NearestNeighbors.jl and Neighborhood.jl. This PR fixes that by specifically importing only the methods we actually use in source files for the closeness-based measures.