### PR TITLE
Test GaussianMI with `normalized=false` and `true`

### DIFF
--- a/test/methods/infomeasures/mutualinfo/estimators.jl
+++ b/test/methods/infomeasures/mutualinfo/estimators.jl
@@ -5,7 +5,8 @@ using LinearAlgebra: det
 
 k = 5
 ests_mi = [
-    GaussianMI(),
+    GaussianMI(normalize=true),
+    GaussianMI(normalize=false),
     KSG1(; k),
     KSG2(; k),
     GaoKannanOhViswanath(; k),

--- a/test/methods/infomeasures/mutualinfo/estimators.jl
+++ b/test/methods/infomeasures/mutualinfo/estimators.jl
@@ -105,7 +105,7 @@ end
     @testset "Compare with analytic eq" begin
         # Test based on https://en.wikipedia.org/wiki/Mutual_information#Linear_correlation.
         # We choose parameters arbitrarily:
-        @testset "normalize=false"
+        @testset "normalize=false" begin
             σ_1 = 1.0
             σ_2 = 1.0
             ρ = 0.5
@@ -124,7 +124,7 @@ end
                 StateSpaceSet(xys[2:2, :]')
             ) ≈ -1/2 * log(1 - ρ^2)  atol=1e-3
         end
-        @testset "normalize=true"
+        @testset "normalize=true" begin
             σ_1 = 0.5
             σ_2 = 1.5
             ρ = 0.5

--- a/test/methods/infomeasures/mutualinfo/estimators.jl
+++ b/test/methods/infomeasures/mutualinfo/estimators.jl
@@ -1,4 +1,5 @@
 using Random
+import Random: seed!
 rng = MersenneTwister(1234)
 using Distributions: MvNormal
 using LinearAlgebra: det
@@ -94,8 +95,31 @@ end
     # The other estimator tests only compute whether the estimators run "at all".
     # For some special cases of the Gaussian we can also compare with a closed form solution.
 
-    x′ = StateSpaceSet(2. .* x.data .+ [SVector(1.)])
-    y′ = StateSpaceSet(3. .* y.data .- [SVector(1.)])
-    @test (  mutualinfo(GaussianMI(normalize=false), x , y)
-           ≈ mutualinfo(GaussianMI(normalize=true) , x′, y′))
+    @testset "Normalized equals unnormalized" begin
+        x′ = StateSpaceSet(2. .* x.data .+ [SVector(1.)])
+        y′ = StateSpaceSet(3. .* y.data .- [SVector(1.)])
+        @test (  mutualinfo(GaussianMI(normalize=false), x , y)
+               ≈ mutualinfo(GaussianMI(normalize=true) , x′, y′))
+    end
+
+    @testset "Compare with analytic eq" begin
+        # Test based on https://en.wikipedia.org/wiki/Mutual_information#Linear_correlation.
+        # We choose parameters arbitrarily:
+        σ_1 = 0.5
+        σ_2 = 1.5
+        ρ = 0.5
+
+        μ = [1.5; 2.5]
+        Σ = [σ_1^2 ρ*σ_1*σ_2;
+             ρ*σ_1*σ_2 σ_2^2]
+
+        seed!(rng, 1)
+        xys = rand(rng, MvNormal(μ, Σ), 10_000)
+
+        @test mutualinfo(
+            GaussianMI(normalize=true),
+            StateSpaceSet(xys[1:1, :]'),
+            StateSpaceSet(xys[2:2, :]')
+        ) ≈ -1/2 * log(1 - ρ^2)  atol=1e-3
+    end
 end

--- a/test/methods/infomeasures/mutualinfo/estimators.jl
+++ b/test/methods/infomeasures/mutualinfo/estimators.jl
@@ -89,3 +89,13 @@ y = StateSpaceSet(rand(rng, 1000, 1))
     end
 
 end
+
+@testset "GaussianMI" begin
+    # The other estimator tests only compute whether the estimators run "at all".
+    # For some special cases of the Gaussian we can also compare with a closed form solution.
+
+    x′ = StateSpaceSet(2. .* x.data .+ [SVector(1.)])
+    y′ = StateSpaceSet(3. .* y.data .- [SVector(1.)])
+    @test (  mutualinfo(GaussianMI(normalize=false), x , y)
+           ≈ mutualinfo(GaussianMI(normalize=true) , x′, y′))
+end


### PR DESCRIPTION
Closes #318 once tests pass.

- [x] include both normalize=true and false in regular testing
- [x] make sure both versions are consistent
- [x] compare with analytic eq

~Test currently fails, although I believe the eq is correct. Probably a bug in the math or implementation somewhere?~