### PR TITLE
Transfer entropy syntax bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/CausalityTools.jl.git"
-version = "2.9.0"
+version = "2.9.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.9
+
+### Bug fixes
+
+- Fixed bug in `transferentropy` function which yielded identical results in both directions for the bivariate case.
+
 ## 2.8.0
 
 Moved to DynamicalSystemsBase v3.0 (`trajectory` now returns both the data and the time

--- a/src/methods/infomeasures/transferentropy/transferentropy.jl
+++ b/src/methods/infomeasures/transferentropy/transferentropy.jl
@@ -119,12 +119,15 @@ include("optimization/optimization.jl")
 include("TEShannon.jl")
 include("TERenyiJizba.jl")
 
-function transferentropy(args...; kwargs...)
-    return estimate(args...; kwargs...)
+function transferentropy(measure::TransferEntropy, est::TE_ESTIMATORS, args...; kwargs...)
+    return estimate(measure, est, args...; kwargs...)
+end
+function transferentropy(est::TE_ESTIMATORS, args...; kwargs...)
+    return estimate(TEShannon(), est, args...; kwargs...)
 end
 
 function estimate(est::TE_ESTIMATORS, args...; kwargs...)
-    estimate(TEShannon(), est, args...; kwargs...)
+    return estimate(TEShannon(), est, args...; kwargs...)
 end
 
 function estimate(measure::TransferEntropy, est::TE_ESTIMATORS, x...)

--- a/test/methods/infomeasures/transferentropy.jl
+++ b/test/methods/infomeasures/transferentropy.jl
@@ -1,5 +1,9 @@
 x, y, z = rand(1000), rand(1000), rand(1000)
 
+# Transfer entropy is asymmetric.
+pest = SymbolicPermutation(m = 2)
+@test transferentropy(TEShannon(), pest, x, y) != transferentropy(TEShannon(), pest, y, x)
+
 est = Lindner( k = 5)
 @test transferentropy(est, x, y) isa Real
 


### PR DESCRIPTION
At some point during the port to DynamicalSystemsBase v3.0, or when making the syntax for two or three input variables explicit, a change was made so that `transferentropy(outcome_space, x, y) == transferentropy(outcome_space, y, x)`. This should in general not be the case, since transfer entropy is asymmetric. 

This PR fixes it.
