### PR TITLE
Use `main` branch for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
       - '**'
   push:
     branches:
-      - master
+      - main
     tags: '*'
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 


### PR DESCRIPTION
Changing the name of the main branch broke some CI builds, including the docs. This PR fixes that.