### PR TITLE
Let multivariate information measures store their parameters directly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 3.0 (new major release)
+
+This release contains a series of breaking changes.
+
+### New information measure API
+
+- Multivariate information measures now store their parameters explicitly, instead 
+    of using `ComplexityMeasures.EntropyDefinition` to do so. For example, to 
+    define Shannon-type conditional mutual information, one should do 
+    `CMIShannon(base = 2)` instead of `CMIShannon(Shannon(base = 2))`.
+- New generic discrete estimator `JointDistribution` for estimating multivariate
+    information measures. This estimators explicitly computes the joint distribution
+    based on the given discretization, and can be applied to any measure which is 
+    defined as a function of a joint distribution.
+- New generic decomposition-based estimator `DifferentialDecomposition`. This estimator
+    computes some multivariate information measure by rewriting the measure definition
+    as a combination of some lower-level measure. For example, `CMIShannon` can be 
+    rewritten as a sum of `Shannon` entropies. Each of these terms can then 
+    be estimated using some differential entropy estimator, e.g. `ZhuSingh` or `Kraskov`.
+- New generic decomposition-based estimator `DiscreteDecomposition`. Works exactly like,
+    `DifferentialDecomposition`, but takes some *discrete* estimator, and some additional
+    parameters that control discretization and probability estimation.
+
 ## 2.10
 
 - Progress bars in some independence tests (surrogate, local permutation) can be

--- a/src/information/information.jl
+++ b/src/information/information.jl
@@ -5,3 +5,7 @@ include("information_measures.jl")
 include("information_functions.jl")
 include("information_estimators/information_estimators.jl")
 include("information_definitions/information_definitions.jl")
+
+# Specific estimators must be included after definitions.
+
+include("information_estimators/mutual_info_estimators/mutual_info_estimators.jl")

--- a/src/information/information_definitions/conditional_entropies/CEShannon.jl
+++ b/src/information/information_definitions/conditional_entropies/CEShannon.jl
@@ -5,7 +5,7 @@ export CEShannon
 
 """
     CEShannon <: ConditionalEntropy
-    CEShannon(; base = 2,)
+    CEShannon(; base = 2)
 
 The [`Shannon`](@ref) conditional entropy measure.
 
@@ -48,21 +48,17 @@ differential entropy and Shannon joint differential entropy, respectively. This 
 definition used when calling [`entropy_conditional`](@ref) with a
 [`DifferentialEntropyEstimator`](@ref).
 """
-struct CEShannon{E} <: ConditionalEntropy
-    e::E
-    function CEShannon(; base = 2)
-        e = Shannon(; base)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct CEShannon{B} <: ConditionalEntropy
+    base::B = 2
 end
 
 function information(definition::CEShannon, pxy::Probabilities{T, 2}) where {T}
-    e = definition.e
+    base = definition.base
     Nx, Ny = size(pxy)
     py = marginal(pxy, dims = 2)
 
     ce = 0.0
-    log0 = log_with_base(e.base)
+    log0 = log_with_base(base)
     for j in 1:Ny
         pyⱼ = py[j]
         for i in 1:Nx

--- a/src/information/information_definitions/conditional_entropies/CETsallisAbe.jl
+++ b/src/information/information_definitions/conditional_entropies/CETsallisAbe.jl
@@ -20,17 +20,13 @@ H_q^{T_A}(X | Y) = \\dfrac{H_q^T(X, Y) - H_q^T(Y)}{1 + (1-q)H_q^T(Y)},
 where ``H_q^T(\\cdot)`` and ``H_q^T(\\cdot, \\cdot)`` is the [`Tsallis`](@ref)
 entropy and the joint Tsallis entropy.
 """
-struct CETsallisAbe{E} <: ConditionalEntropy
-    e::E
-    function CETsallisAbe(; q = 1.5, base = 2)
-        e = Tsallis(; q, base)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct CETsallisAbe{B, Q} <: ConditionalEntropy
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::CETsallisAbe, pxy::Probabilities{T, 2}) where {T}
-    e = definition.e
-    base, q = e.base, e.q
+    (; base, q) = definition
 
     py = marginal(pxy, dims = 2)
     # Definition 7 in Abe & Rajagopal (2001)

--- a/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
+++ b/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
@@ -27,20 +27,17 @@ p(x, y) \\log(p(x | y))
 If any of the entries of the marginal distribution for `Y` are zero, then the 
 measure is undefined and `NaN` is returned.
 """
-struct CETsallisFuruichi{E} <: ConditionalEntropy
-    e::E
-    function CETsallisFuruichi(; q = 1.5, base = 2)
-        e = Tsallis(; q, base)
-        new{typeof(e)}(e)
-    end
+struct CETsallisFuruichi{B, Q} <: ConditionalEntropy
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::CETsallisFuruichi, pxy::Probabilities{T, 2}) where {T}
-    e = definition.e
+    (; base, q) = definition
     Nx, Ny = size(pxy)
     q = e.q
     if q == 1
-        return information(CEShannon(; base = definition.e.base), pxy)
+        return information(CEShannon(; base), pxy)
     end
     py = marginal(pxy, dims = 2)
     ce = 0.0

--- a/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
+++ b/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
@@ -27,7 +27,7 @@ p(x, y) \\log(p(x | y))
 If any of the entries of the marginal distribution for `Y` are zero, then the 
 measure is undefined and `NaN` is returned.
 """
-struct CETsallisFuruichi{B, Q} <: ConditionalEntropy
+Base.@kwdef struct CETsallisFuruichi{B, Q} <: ConditionalEntropy
     base::B = 2
     q::Q = 1.5
 end

--- a/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
+++ b/src/information/information_definitions/conditional_entropies/CETsallisFuruichi.jl
@@ -35,10 +35,10 @@ end
 function information(definition::CETsallisFuruichi, pxy::Probabilities{T, 2}) where {T}
     (; base, q) = definition
     Nx, Ny = size(pxy)
-    q = e.q
     if q == 1
         return information(CEShannon(; base), pxy)
     end
+    
     py = marginal(pxy, dims = 2)
     ce = 0.0
     qlog = logq0(q)

--- a/src/information/information_definitions/conditional_mutual_informations/CMIRenyiJizba.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/CMIRenyiJizba.jl
@@ -4,6 +4,7 @@ export CMIRenyiJizba
 
 """
     CMIRenyiJizba <: ConditionalMutualInformation
+    CMIRenyiJizba(; base = 2, q = 1.5)
 
 The Rényi conditional mutual information ``I_q^{R_{J}}(X; Y | Z`` defined in
 [Jizba2012](@citet).
@@ -21,15 +22,9 @@ I_q^{R_{J}}(X; Y | Z) = I_q^{R_{J}}(X; Y, Z) - I_q^{R_{J}}(X; Z),
 
 where ``I_q^{R_{J}}(X; Z)`` is the [`MIRenyiJizba`](@ref) mutual information.
 """
-struct CMIRenyiJizba{E <: Renyi} <: ConditionalMutualInformation
-    e::E
-    function CMIRenyiJizba(; base = 2, q = 1.5)
-        e = Renyi(; base, q)
-        new{typeof(e)}(e)
-    end
-    function CMIRenyiJizba(e::E) where E <: Renyi
-        new{E}(e)
-    end
+Base.@kwdef struct CMIRenyiJizba{B, Q} <: ConditionalMutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(est::JointProbabilities{<:CMIRenyiJizba}, x, y, z)

--- a/src/information/information_definitions/conditional_mutual_informations/CMIRenyiPoczos.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/CMIRenyiPoczos.jl
@@ -4,6 +4,7 @@ export CMIRenyiPoczos
 
 """
     CMIRenyiPoczos <: ConditionalMutualInformation
+    CMIRenyiPoczos(; base = 2, q = 1.5)
 
 The differential Rényi conditional mutual information ``I_q^{R_{P}}(X; Y | Z)``
 defined in (Póczos & Schneider, 2012)[^Póczos2012].
@@ -29,13 +30,7 @@ I_q^{R_{P}}(X; Y | Z) = \\dfrac{1}{q-1}
     information and divergences. In Artificial Intelligence and Statistics (pp. 914-923).
     PMLR.
 """
-struct CMIRenyiPoczos{E <: Renyi} <: ConditionalMutualInformation
-    e::E
-    function CMIRenyiPoczos(; base = 2, q = 1.5)
-        e = Renyi(; base, q)
-        new{typeof(e)}(e)
-    end
-    function CMIRenyiPoczos(e::E) where E <: Renyi
-        new{E}(e)
-    end
+Base.@kwdef struct CMIRenyiPoczos{B, Q} <: ConditionalMutualInformation
+    base::B = 2
+    q::Q = 1.5
 end

--- a/src/information/information_definitions/conditional_mutual_informations/CMIRenyiSarbu.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/CMIRenyiSarbu.jl
@@ -5,7 +5,7 @@ export CMIRenyiSarbu
 
 """
     CMIRenyiSarbu <: ConditionalMutualInformation
-    CMIRenyiSarbu(; base = 2, definition = CMIRenyiSarbuSarbu())
+    CMIRenyiSarbu(; base = 2, q = 1.5)
 
 The Rényi conditional mutual information from [Sarbu2014](@citet).
 
@@ -32,24 +32,21 @@ I(X, Y; Z)^R_q =
 
 See also: [`condmutualinfo`](@ref).
 """
-struct CMIRenyiSarbu{E <: Renyi} <: ConditionalMutualInformation
-    e::E
-    function CMIRenyiSarbu(; base = 2, q = 1.5)
-        e = Renyi(; base, q)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct CMIRenyiSarbu{B, Q} <: ConditionalMutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::CMIRenyiSarbu, pxyz::Probabilities{T, 3}) where T
-    e = definition.e
-    q = e.q
+    (; base, q) = definition
+
     dx, dy, dz = size(pxyz)
     pxz = marginal(pxyz, dims = [1, 3])
     pyz = marginal(pxyz, dims = [2, 3])
     pz = marginal(pxyz, dims = 3)
 
     cmi = 0.0
-    logb = log_with_base(e.base)
+    logb = log_with_base(base)
     for k in 1:dz
         pzₖ = pz[k]
         inner = 0.0
@@ -70,10 +67,10 @@ function information(definition::CMIRenyiSarbu, pxyz::Probabilities{T, 3}) where
     return 1 / (q - 1) * cmi
 end
 
-function information(est::DifferentialDecomposition{<:CMIRenyiSarbu}, x, y)
+function information(est::DifferentialDecomposition{<:CMIRenyiSarbu}, args...)
     throw(ArgumentError("CMIRenyiSarbu not implemented for $(typeof(est).name.name)"))
 end
 
-function information(est::DiscreteDecomposition{<:CMIRenyiSarbu}, x, y)
+function information(est::DiscreteDecomposition{<:CMIRenyiSarbu}, args...)
     throw(ArgumentError("CMIRenyiSarbu not implemented for $(typeof(est).name.name)"))
 end

--- a/src/information/information_definitions/conditional_mutual_informations/CMIShannon.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/CMIShannon.jl
@@ -36,25 +36,17 @@ differential entropies.
 
 See also: [`condmutualinfo`](@ref).
 """
-struct CMIShannon{E <: Shannon} <: ConditionalMutualInformation
-    e::E
-    function CMIShannon(; base::T = 2) where {T <: Real}
-        e = Shannon(; base)
-        new{typeof(e)}(e)
-    end
-    function CMIShannon(e::E) where E <: Shannon
-        new{E}(e)
-    end
+Base.@kwdef struct CMIShannon{B} <: ConditionalMutualInformation
+    base::B = 2
 end
 
 function information(definition::CMIShannon, pxyz::Probabilities{T, 3}) where T
-    e = definition.e
     dx, dy, dz = size(pxyz)
     pxz = marginal(pxyz, dims = [1, 3])
     pyz = marginal(pxyz, dims = [2, 3])
     pz = marginal(pxyz, dims = 3)
     cmi = 0.0
-    log0 = log_with_base(e.base)
+    log0 = log_with_base(definition.base)
     for k in 1:dz
         pzₖ = pz[k]
         for j in 1:dy

--- a/src/information/information_definitions/conditional_mutual_informations/CMITsallis.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/CMITsallis.jl
@@ -5,25 +5,25 @@ export CMITsallis
 
 """
     CMITsallis <: ConditionalMutualInformation
-    CMITsallis(; q = 1.5, base = 2)
+    CMITsallis(; base = 2, q = 1.5)
 """
-struct CMITsallis{E <: Tsallis} <: ConditionalMutualInformation
-    e::E
-    function CMITsallis(; base::T = 2, q = 1.5) where {T <: Real}
-        e = Tsallis(; base, q)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct CMITsallis{B, Q} <: ConditionalMutualInformation
+    base::B = 2
+    q::Q = 1.5 # Todo: check formula. Where does `q` appear?
 end
 
-function information(measure::CMITsallis, pxyz::Probabilities{T, 3}) where T
-    e = measure.e
+# TODO: this has to be wrong. See the following paper for a definition:
+# https://www.sciencedirect.com/science/article/pii/S0378437119317030?casa_token=OjBFqwe6_1UAAAAA:s32zgg706dkO5P8Wuy2x2fWX0WjR09IguDvA8xGt6OTthjGkTAAutiZSiqI49ScyA6nTwomXEw
+function information(definition::CMITsallis, pxyz::Probabilities{T, 3}) where T
+    (; base, q) = definition
+
     dx, dy, dz = size(pxyz)
     pxz = marginal(pxyz, dims = [1, 3])
     pyz = marginal(pxyz, dims = [2, 3])
     pz = marginal(pxyz, dims = 3)
 
     cmi = 0.0
-    log0 = log_with_base(e.base)
+    log0 = log_with_base(base)
     for k in 1:dz
         pzₖ = pz[k]
         for j in 1:dy

--- a/src/information/information_definitions/conditional_mutual_informations/conditional_mutual_informations.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/conditional_mutual_informations.jl
@@ -5,7 +5,7 @@ max_inputs_vars(::ConditionalMutualInformation) = 3
 
 
 # Generic H4-formulation of CMI
-function marginal_entropies_cmi4h_differential(est::DifferentialDecomposition{<:ConditionalMutualInformation, <:DifferentialInfoEstimator}, x, y, z)
+function marginal_entropies_cmi4h_differential(est::EntropyDecomposition{<:ConditionalMutualInformation, <:DifferentialInfoEstimator}, x, y, z)
     Z = StateSpaceSet(z)
     Y = StateSpaceSet(y)
     X = StateSpaceSet(x)
@@ -22,7 +22,7 @@ function marginal_entropies_cmi4h_differential(est::DifferentialDecomposition{<:
     return HXZ, HYZ, HXYZ, HZ
 end
 
-function marginal_entropies_cmi4h_discrete(est::DiscreteDecomposition{<:ConditionalMutualInformation, <:DiscreteInfoEstimator}, x, y, z)
+function marginal_entropies_cmi4h_discrete(est::EntropyDecomposition{<:ConditionalMutualInformation, <:DiscreteInfoEstimator}, x, y, z)
     # Encode marginals to integers based on the outcome space.
     eX, eY, eZ = codified_marginals(est.discretization, x, y, z)
     eXZ = StateSpaceSet(eX, eZ)

--- a/src/information/information_definitions/conditional_mutual_informations/conditional_mutual_informations.jl
+++ b/src/information/information_definitions/conditional_mutual_informations/conditional_mutual_informations.jl
@@ -13,28 +13,31 @@ function marginal_entropies_cmi4h_differential(est::DifferentialDecomposition{<:
     YZ = StateSpaceSet(Y, Z)
     XYZ = StateSpaceSet(X, Y, Z)
 
-    HXZ = entropy(est.est, XZ)
-    HYZ = entropy(est.est, YZ)
-    HXYZ = entropy(est.est, XYZ)
-    HZ = entropy(est.est, Z)
+    modified_est = estimator_with_overridden_parameters(est.definition, est.est)
+    HXZ = entropy(modified_est, XZ)
+    HYZ = entropy(modified_est, YZ)
+    HXYZ = entropy(modified_est, XYZ)
+    HZ = entropy(modified_est, Z)
 
     return HXZ, HYZ, HXYZ, HZ
 end
 
-function marginal_entropies_cmi4h_discrete(est::DifferentialDecomposition{<:ConditionalMutualInformation, <:DifferentialInfoEstimator}, x, y, z)
+function marginal_entropies_cmi4h_discrete(est::DiscreteDecomposition{<:ConditionalMutualInformation, <:DiscreteInfoEstimator}, x, y, z)
     # Encode marginals to integers based on the outcome space.
-    eX, eY, eZ = codified_marginals(est, x, y, z)
+    eX, eY, eZ = codified_marginals(est.discretization, x, y, z)
     eXZ = StateSpaceSet(eX, eZ)
     eYZ = StateSpaceSet(eY, eZ)
     eXYZ = StateSpaceSet(eX, eY, eZ)
  
     # The outcome space is no longer relevant from this point on. We're done discretizing, 
-    # so now we can just count (i.e. use `UniqueElements`).
+    # so now we can just count (i.e. use `UniqueElements` as the outcome space).
     o = UniqueElements()
-    HXZ = information(est.mest, est.pest, o, eXZ)
-    HYZ = information(est.mest, est.pest, o, eYZ)
-    HXYZ = information(est.mest, est.pest, o, eXYZ)
-    HZ = information(est.mest, est.pest, o, eZ)
+
+    modified_est = estimator_with_overridden_parameters(est.definition, est.mest)
+    HXZ = information(modified_est, est.pest, o, eXZ)
+    HYZ = information(modified_est, est.pest, o, eYZ)
+    HXYZ = information(modified_est, est.pest, o, eXYZ)
+    HZ = information(modified_est, est.pest, o, eZ)
 
     return HXZ, HYZ, HXYZ, HZ
 end

--- a/src/information/information_definitions/divergences_and_distances/RenyiDivergence.jl
+++ b/src/information/information_definitions/divergences_and_distances/RenyiDivergence.jl
@@ -35,10 +35,10 @@ struct RenyiDivergence{Q, B} <: DivergenceOrDistance
         new{Q, B}(q, base)
     end
 end
-RenyiDivergence(;q = 0.5, base = 2) = RenyiDivergence(q, base)
+RenyiDivergence(; q = 0.5, base = 2) = RenyiDivergence(q, base)
 
-function information(measure::RenyiDivergence, px::Probabilities, py::Probabilities)
-    base, q = measure.base, measure.q
+function information(definition::RenyiDivergence, px::Probabilities, py::Probabilities)
+    (; base, q)
 
     if q == Inf
         return maximum(pxᵢ / pyᵢ for (pxᵢ, pyᵢ) in zip(px, py))

--- a/src/information/information_definitions/divergences_and_distances/RenyiDivergence.jl
+++ b/src/information/information_definitions/divergences_and_distances/RenyiDivergence.jl
@@ -38,7 +38,7 @@ end
 RenyiDivergence(; q = 0.5, base = 2) = RenyiDivergence(q, base)
 
 function information(definition::RenyiDivergence, px::Probabilities, py::Probabilities)
-    (; base, q)
+    (; base, q) = definition
 
     if q == Inf
         return maximum(pxᵢ / pyᵢ for (pxᵢ, pyᵢ) in zip(px, py))

--- a/src/information/information_definitions/information_definitions.jl
+++ b/src/information/information_definitions/information_definitions.jl
@@ -1,3 +1,4 @@
+
 include("divergences_and_distances/divergences_and_distances.jl")
 include("joint_entropies/joint_entropies.jl")
 include("conditional_entropies/conditional_entropies.jl")
@@ -5,3 +6,5 @@ include("mutual_informations/mutual_informations.jl")
 include("conditional_mutual_informations/conditional_mutual_informations.jl")
 
 include("partial_mutual_information.jl")
+
+include("override_parameters.jl")

--- a/src/information/information_definitions/joint_entropies/JointEntropyRenyi.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyRenyi.jl
@@ -19,17 +19,14 @@ H_q^R(X, Y) = \\dfrac{1}{1-\\alpha} \\log \\sum_{i = 1}^N p_i^q,
 
 where ``q > 0`` and ``q != 1``.
 """
-struct JointEntropyRenyi{E<:Renyi} <: JointEntropy
-    e::E
-    function JointEntropyRenyi(; base = 2, q = 1.5)
-        e = Renyi(; base, q)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct JointEntropyRenyi{B, Q} <: JointEntropy
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::JointEntropyRenyi, pxy::Probabilities{T, 2}) where T
-    base = definition.e.base
-    q = definition.e.q
+    (; base, q) = definition
+    
     h = 0.0
     for p in pxy
         if p != 0

--- a/src/information/information_definitions/joint_entropies/JointEntropyShannon.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyShannon.jl
@@ -17,16 +17,13 @@ Given two two discrete random variables ``X`` and ``Y`` with ranges ``\\mathcal{
 H^S(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y) \\log p(x, y)
 ```
 """
-struct JointEntropyShannon{E<:Shannon} <: JointEntropy
-    e::E
-    function JointEntropyShannon(; base = 2)
-        e = Shannon(; base)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct JointEntropyShannon{B} <: JointEntropy
+    base::B = 2
 end
 
 function information(definition::JointEntropyShannon, pxy::Probabilities{T, 2}) where T
-    base = definition.e.base
+    (; base) = definition
+    
     h = 0.0
     for p in pxy
         h += p * log(p)

--- a/src/information/information_definitions/joint_entropies/JointEntropyShannon.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyShannon.jl
@@ -14,8 +14,10 @@ Given two two discrete random variables ``X`` and ``Y`` with ranges ``\\mathcal{
 ``\\mathcal{X}``, [CoverThomas2006](@citet) defines the Shannon joint entropy as
 
 ```math
-H^S(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y) \\log p(x, y)
+H^S(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y) \\log p(x, y),
 ```
+
+where we define ``log(p(x, y)) := 0`` if ``p(x, y) = 0``.
 """
 Base.@kwdef struct JointEntropyShannon{B} <: JointEntropy
     base::B = 2
@@ -26,7 +28,9 @@ function information(definition::JointEntropyShannon, pxy::Probabilities{T, 2}) 
     
     h = 0.0
     for p in pxy
-        h += p * log(p)
+        if p != 0 # Define log(0) = 0
+            h += p * log(p)
+        end
     end
     h = -h
     return _convert_logunit(h, ℯ, base)

--- a/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
@@ -29,7 +29,9 @@ function information(definition::JointEntropyTsallis, pxy::Probabilities{T, 2}) 
     
     h = 0.0
     for p in pxy
-        h += p^q * logq(p, q)
+        if p != 0.0 # logq will error if probability is zero.
+            h += p^q * logq(p, q)
+        end
     end
     h = -h
     return _convert_logunit(h, ℯ, base)

--- a/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
@@ -14,10 +14,11 @@ Given two two discrete random variables ``X`` and ``Y`` with ranges ``\\mathcal{
 ``\\mathcal{X}``, [Furuichi2006](@citet) defines the Tsallis joint entropy as
 
 ```math
-H_q^T(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y)^q \\log_q p(x, y)
+H_q^T(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y)^q \\log_q p(x, y),
 ```
 
-where ``log_q(x, q) = \\dfrac{x^{1-q} - 1}{1-q}`` is the q-logarithm.
+where ``log_q(x, q) = \\dfrac{x^{1-q} - 1}{1-q}`` is the q-logarithm, and 
+we define ``log_q(x, q) := 0`` if ``q = 0``.
 """
 Base.@kwdef struct JointEntropyTsallis{B, Q} <: JointEntropy
     base::B = 2
@@ -29,7 +30,7 @@ function information(definition::JointEntropyTsallis, pxy::Probabilities{T, 2}) 
     
     h = 0.0
     for p in pxy
-        if p != 0.0 # logq will error if probability is zero.
+        if p != 0.0 # Define logq(0) = 0
             h += p^q * logq(p, q)
         end
     end

--- a/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
+++ b/src/information/information_definitions/joint_entropies/JointEntropyTsallis.jl
@@ -19,17 +19,14 @@ H_q^T(X, Y) = -\\sum_{x\\in \\mathcal{X}, y \\in \\mathcal{Y}} p(x, y)^q \\log_q
 
 where ``log_q(x, q) = \\dfrac{x^{1-q} - 1}{1-q}`` is the q-logarithm.
 """
-struct JointEntropyTsallis{E<:Tsallis} <: JointEntropy
-    e::E
-    function JointEntropyTsallis(; base = 2, q = 1.5)
-        e = Tsallis(; base, q)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct JointEntropyTsallis{B, Q} <: JointEntropy
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::JointEntropyTsallis, pxy::Probabilities{T, 2}) where T
-    base = definition.e.base
-    q = definition.e.q
+    (; base, q) = definition
+    
     h = 0.0
     for p in pxy
         h += p^q * logq(p, q)

--- a/src/information/information_definitions/mutual_informations/MIRenyiJizba.jl
+++ b/src/information/information_definitions/mutual_informations/MIRenyiJizba.jl
@@ -50,3 +50,12 @@ function information(definition::MIRenyiJizba, pxy::Probabilities{T, 2}) where T
 
     return (1 / (1 / q)) * mi
 end
+
+
+function information(est::EntropyDecomposition{<:MIRenyiJizba}, x, y)
+    throw(ArgumentError("MIRenyiSarbu not implemented for $(typeof(est).name.name)"))
+end
+
+function information(est::EntropyDecomposition{<:MIRenyiJizba}, x, y)
+    throw(ArgumentError("MIRenyiSarbu not implemented for $(typeof(est).name.name)"))
+end

--- a/src/information/information_definitions/mutual_informations/MIRenyiJizba.jl
+++ b/src/information/information_definitions/mutual_informations/MIRenyiJizba.jl
@@ -22,23 +22,18 @@ I_q^{R_{J}}(X; Y) = S_q^{R}(X) + S_q^{R}(Y) - S_q^{R}(X, Y),
 where ``S_q^{R}(\\cdot)`` and ``S_q^{R}(\\cdot, \\cdot)`` the [`Rényi`](@ref) entropy and
 the joint Rényi entropy.
 """
-struct MIRenyiJizba{E <: Renyi} <: MutualInformation
-    e::E
-    function MIRenyiJizba(; q = 1.5, base = 2)
-        e = Renyi(; q, base)
-        new{typeof(e)}(e)
-    end
-    function MIRenyiJizba(e::E) where E <: Renyi
-        new{E}(e)
-    end
+Base.@kwdef struct MIRenyiJizba{B, Q} <: MutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::MIRenyiJizba, pxy::Probabilities{T, 2}) where T
-    e = definition.e
-    q = e.q
+    (; base, q) = definition
+
     px = marginal(pxy, dims = 1)
     py = marginal(pxy, dims = 2)
-    logb = log_with_base(e.base)
+    
+    logb = log_with_base(base)
     num = 0.0
     den = 0.0
     for i in eachindex(px.p)

--- a/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
+++ b/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
@@ -29,7 +29,7 @@ I(X, Y)^R_q =
 ```
 See also: [`mutualinfo`](@ref).
 """
-struct MIRenyiSarbu{B, Q} <: MutualInformation
+Base.@kwdef struct MIRenyiSarbu{B, Q} <: MutualInformation
     base::B = 2
     q::Q = 1.5
 end

--- a/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
+++ b/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
@@ -29,19 +29,16 @@ I(X, Y)^R_q =
 ```
 See also: [`mutualinfo`](@ref).
 """
-struct MIRenyiSarbu{E <: Renyi} <: MutualInformation
-    e::E
-    function MIRenyiSarbu(; q = 1.5, base = 2)
-        e = Renyi(; q, base)
-        new{typeof(e)}(e)
-    end
+struct MIRenyiSarbu{B, Q} <: MutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::MIRenyiSarbu, pxy::Probabilities{T, 2}) where T
+    (; base, q) = definition
+
     px = marginal(pxy, dims = 1)
     py = marginal(pxy, dims = 2)
-    e = definition.e
-    q = e.q
 
     mi = 0.0
     for i in eachindex(px.p)
@@ -53,7 +50,7 @@ function information(definition::MIRenyiSarbu, pxy::Probabilities{T, 2}) where T
     if mi == 0
         return 0.0
     else
-        return _convert_logunit(1 / (q - 1) * log(mi), ℯ, e.base)
+        return _convert_logunit(1 / (q - 1) * log(mi), ℯ, base)
     end
 end
 

--- a/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
+++ b/src/information/information_definitions/mutual_informations/MIRenyiSarbu.jl
@@ -54,10 +54,10 @@ function information(definition::MIRenyiSarbu, pxy::Probabilities{T, 2}) where T
     end
 end
 
-function information(est::DifferentialDecomposition{<:MIRenyiSarbu}, x, y)
+function information(est::EntropyDecomposition{<:MIRenyiSarbu}, x, y)
     throw(ArgumentError("MIRenyiSarbu not implemented for $(typeof(est).name.name)"))
 end
 
-function information(est::DiscreteDecomposition{<:MIRenyiSarbu}, x, y)
+function information(est::EntropyDecomposition{<:MIRenyiSarbu}, x, y)
     throw(ArgumentError("MIRenyiSarbu not implemented for $(typeof(est).name.name)"))
 end

--- a/src/information/information_definitions/mutual_informations/MIShannon.jl
+++ b/src/information/information_definitions/mutual_informations/MIShannon.jl
@@ -94,15 +94,15 @@ end
 # ------------------------------------------------
 # Mutual information through entropy decomposition
 # ------------------------------------------------
-function information(est::DifferentialDecomposition{<:MIShannon, <:DifferentialInfoEstimator{<:Shannon}}, x, y)
+function information(est::EntropyDecomposition{<:MIShannon, <:DifferentialInfoEstimator{<:Shannon}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h_differential(est, x, y)
     mi =  HX + HY - HXY
     return mi
 end
 
-function information(est::DiscreteDecomposition{<:MIShannon, <:DiscreteInfoEstimator{<:Shannon}}, x, y)
+function information(est::EntropyDecomposition{<:MIShannon, <:DiscreteInfoEstimator{<:Shannon}, D, P}, x, y) where {D, P}
     HX, HY, HXY = marginal_entropies_mi3h_discrete(est, x, y)
-    mi = HX + HY - HXY
+    mi =  HX + HY - HXY
     return mi
 end
 

--- a/src/information/information_definitions/mutual_informations/MIShannon.jl
+++ b/src/information/information_definitions/mutual_informations/MIShannon.jl
@@ -65,24 +65,18 @@ called with a [`DifferentialEntropyEstimator`](@ref).
 
 See also: [`mutualinfo`](@ref).
 """
-struct MIShannon{E <: Shannon} <: MutualInformation
-    e::E
-    function MIShannon(; base::Real = 2)
-        e = Shannon(; base)
-        new{typeof(e)}(e)
-    end
-    function MIShannon(e::Shannon)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct MIShannon{B} <: MutualInformation
+    base::B = 2
 end
 
 # Double-sum estimation.
 function information(definition::MIShannon, pxy::Probabilities{T, 2}) where T
-    e = definition.e
+    (; base) = definition
+    
     px = marginal(pxy, dims = 1)
     py = marginal(pxy, dims = 2)
     mi = 0.0
-    logb = log_with_base(e.base)
+    logb = log_with_base(base)
     for i in eachindex(px.p)
         pxᵢ = px[i]
         for j in eachindex(py.p)

--- a/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
@@ -29,17 +29,14 @@ entropies, and `q` is the [`Tsallis`](@ref)-parameter.
 
 See also: [`mutualinfo`](@ref).
 """
-struct MITsallisFuruichi{E <: Tsallis} <: MutualInformation
-    e::E
-    function MITsallisFuruichi(; q = 1.5, base = 2)
-        e = Tsallis(; q, base)
-        new{typeof(e)}(e)
-    end
+struct MITsallisFuruichi{B, Q} <: MutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 function information(definition::MITsallisFuruichi, pxy::Probabilities{T, 2}) where T
-    e = definition.e
-    q = definition.e.q
+    (; base, q) = definition
+
     px = marginal(pxy, dims = 1)
     py = marginal(pxy, dims = 2)
 
@@ -51,7 +48,7 @@ function information(definition::MITsallisFuruichi, pxy::Probabilities{T, 2}) wh
         end
     end
     mi = (1 / (q - 1) * (1 - mi) / (1-q))
-    return _convert_logunit(mi, ℯ, e.base)
+    return _convert_logunit(mi, ℯ, base)
 end
 
 

--- a/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
@@ -29,7 +29,7 @@ entropies, and `q` is the [`Tsallis`](@ref)-parameter.
 
 See also: [`mutualinfo`](@ref).
 """
-struct MITsallisFuruichi{B, Q} <: MutualInformation
+Base.@kwdef struct MITsallisFuruichi{B, Q} <: MutualInformation
     base::B = 2
     q::Q = 1.5
 end

--- a/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisFuruichi.jl
@@ -53,13 +53,13 @@ end
 
 
 
-function information(est::DifferentialDecomposition{<:MITsallisFuruichi, <:DifferentialInfoEstimator{<:Tsallis}}, x, y)
+function information(est::EntropyDecomposition{<:MITsallisFuruichi, <:DifferentialInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h(est, x, y)
     mi = HX + HY - HXY
     return mi
 end
 
-function information(est::DiscreteDecomposition{<:MITsallisFuruichi, <:DiscreteInfoEstimator{<:Tsallis}}, x, y)
+function information(est::EntropyDecomposition{<:MITsallisFuruichi, <:DiscreteInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h_discrete(est, x, y)
     mi = HX + HY - HXY
     return mi

--- a/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
@@ -55,14 +55,14 @@ end
 
 function information(est::DifferentialDecomposition{<:MITsallisMartin, <:DifferentialInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h(est, x, y)
-    q = est.definition.e.q
+    q = est.definition.q
     mi = HX + HY - (1 - q) * HX * HY - HXY
     return mi
 end
 
 function information(est::DiscreteDecomposition{<:MITsallisMartin, <:DiscreteInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h_discrete(est, x, y)
-    q = est.definition.e.q
+    q = est.definition.q
     mi = HX + HY - (1 - q) * HX * HY - HXY
     return mi
 end

--- a/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
@@ -53,14 +53,14 @@ function information(definition::MITsallisMartin, pxy::Probabilities{T, 2}) wher
     return f * (1 - mi)
 end
 
-function information(est::DifferentialDecomposition{<:MITsallisMartin, <:DifferentialInfoEstimator{<:Tsallis}}, x, y)
+function information(est::EntropyDecomposition{<:MITsallisMartin, <:DifferentialInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h(est, x, y)
     q = est.definition.q
     mi = HX + HY - (1 - q) * HX * HY - HXY
     return mi
 end
 
-function information(est::DiscreteDecomposition{<:MITsallisMartin, <:DiscreteInfoEstimator{<:Tsallis}}, x, y)
+function information(est::EntropyDecomposition{<:MITsallisMartin, <:DiscreteInfoEstimator{<:Tsallis}}, x, y)
     HX, HY, HXY = marginal_entropies_mi3h_discrete(est, x, y)
     q = est.definition.q
     mi = HX + HY - (1 - q) * HX * HY - HXY

--- a/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
+++ b/src/information/information_definitions/mutual_informations/MITsallisMartin.jl
@@ -28,19 +28,16 @@ entropies, and `q` is the [`Tsallis`](@ref)-parameter.
 
 See also: [`mutualinfo`](@ref).
 """
-struct MITsallisMartin{E <: Tsallis} <: MutualInformation
-    e::E
-    function MITsallisMartin(; q = 1.5, base = 2)
-        e = Tsallis(; q, base)
-        new{typeof(e)}(e)
-    end
+Base.@kwdef struct MITsallisMartin{B, Q} <: MutualInformation
+    base::B = 2
+    q::Q = 1.5
 end
 
 # This is definition 3 in Martin et al. (2004), but with pᵢ replaced by the joint
 # distribution and qᵢ replaced by the product of the marginal distributions.
 function information(definition::MITsallisMartin, pxy::Probabilities{T, 2}) where T
-    e = definition.e
-    q = definition.e.q
+    (; base, q) = definition
+    # TODO: return MIShannon if q = 1? otherwise, we don't need `base`.
     q != 1 || throw(ArgumentError("`MITsallisMartin` for q=$(q) not defined."))
     px = marginal(pxy, dims = 1)
     py = marginal(pxy, dims = 2)

--- a/src/information/information_definitions/mutual_informations/mutual_informations.jl
+++ b/src/information/information_definitions/mutual_informations/mutual_informations.jl
@@ -2,7 +2,7 @@ abstract type MutualInformation <: BivariateInformationMeasure end
 
 # Generic 3H-formulation of Shannon mutual information (a scaled sum of these entropies are also used by 
 # some of the other mutual information measures, so we define it generically here).
-function marginal_entropies_mi3h_differential(est::DifferentialDecomposition{<:MutualInformation, <:DifferentialInfoEstimator}, x, y)
+function marginal_entropies_mi3h_differential(est::EntropyDecomposition{<:MutualInformation, <:DifferentialInfoEstimator}, x, y)
     X = StateSpaceSet(x)
     Y = StateSpaceSet(y)
     XY = StateSpaceSet(X, Y)
@@ -13,7 +13,7 @@ function marginal_entropies_mi3h_differential(est::DifferentialDecomposition{<:M
     return HX, HY, HXY
 end
 
-function marginal_entropies_mi3h_discrete(est::DiscreteDecomposition{<:MutualInformation, <:DiscreteInfoEstimator}, x, y)
+function marginal_entropies_mi3h_discrete(est::EntropyDecomposition{<:MutualInformation, <:DiscreteInfoEstimator}, x, y)
     # Encode marginals to integers based on the outcome space.
     eX, eY = codified_marginals(est.discretization, x, y)
     eXY = StateSpaceSet(eX, eY)
@@ -22,7 +22,7 @@ function marginal_entropies_mi3h_discrete(est::DiscreteDecomposition{<:MutualInf
     # so now we can just count (i.e. use `UniqueElements` as the outcome space).
     o = UniqueElements()
 
-    modified_est = estimator_with_overridden_parameters(est.definition, est.mest)
+    modified_est = estimator_with_overridden_parameters(est.definition, est.est)
     HX = information(modified_est, est.pest, o, eX) # estimates entropy in the X marginal
     HY = information(modified_est, est.pest, o, eY) # estimates entropy in the Y marginal
     HXY = information(modified_est, est.pest, o, eXY) # estimates entropy in the joint XY space

--- a/src/information/information_definitions/mutual_informations/mutual_informations.jl
+++ b/src/information/information_definitions/mutual_informations/mutual_informations.jl
@@ -6,9 +6,10 @@ function marginal_entropies_mi3h_differential(est::DifferentialDecomposition{<:M
     X = StateSpaceSet(x)
     Y = StateSpaceSet(y)
     XY = StateSpaceSet(X, Y)
-    HX = information(est.est, X) # estimates entropy in the X marginal
-    HY = information(est.est, Y) # estimates entropy in the Y marginal
-    HXY = information(est.est, XY) # estimates entropy in the joint XY space
+    modified_est = estimator_with_overridden_parameters(est.definition, est.est)
+    HX = information(modified_est, X) # estimates entropy in the X marginal
+    HY = information(modified_est, Y) # estimates entropy in the Y marginal
+    HXY = information(modified_est, XY) # estimates entropy in the joint XY space
     return HX, HY, HXY
 end
 
@@ -18,11 +19,13 @@ function marginal_entropies_mi3h_discrete(est::DiscreteDecomposition{<:MutualInf
     eXY = StateSpaceSet(eX, eY)
 
     # The outcome space is no longer relevant from this point on. We're done discretizing, 
-    # so now we can just count (i.e. use `UniqueElements`).
+    # so now we can just count (i.e. use `UniqueElements` as the outcome space).
     o = UniqueElements()
-    HX = information(est.mest, est.pest, o, eX) # estimates entropy in the X marginal
-    HY = information(est.mest, est.pest, o, eY) # estimates entropy in the Y marginal
-    HXY = information(est.mest, est.pest, o, eXY) # estimates entropy in the joint XY space
+
+    modified_est = estimator_with_overridden_parameters(est.definition, est.mest)
+    HX = information(modified_est, est.pest, o, eX) # estimates entropy in the X marginal
+    HY = information(modified_est, est.pest, o, eY) # estimates entropy in the Y marginal
+    HXY = information(modified_est, est.pest, o, eXY) # estimates entropy in the joint XY space
     
     return HX, HY, HXY
 end

--- a/src/information/information_definitions/override_parameters.jl
+++ b/src/information/information_definitions/override_parameters.jl
@@ -1,0 +1,31 @@
+using Accessors: @set
+
+export estimator_with_overridden_parameters
+
+# For internal use only.
+"""
+    estimator_with_overridden_parameters(definition, lower_level_estimator) → e::typeof(lower_level_estimator)
+
+Given some higher-level `definition` of an information measure, which is to be 
+estimated using some `lower_level_estimator`, return a modified version of 
+the estimator in which its parameter have been overriden by any overlapping
+parameters from the `defintiion`.
+
+This method is explicitly extended for each possible decomposition.
+"""
+function estimator_with_overridden_parameters(definition, lower_level_estimator) end
+
+const TSALLIS_MULTIVARIATE_MEASURES = Union{
+    CMITsallis, 
+    MITsallisFuruichi, MITsallisMartin,
+    CETsallisAbe, CETsallisFuruichi,
+    JointEntropyTsallis,
+}
+
+function estimator_with_overridden_parameters(defintion::CMITsallis, 
+        est::InformationMeasureEstimator{<:Tsallis})
+    modified_est = @set est.base = definition.base
+    modified_est = @set est.q = definition.q
+
+    return modified_est
+end

--- a/src/information/information_definitions/override_parameters.jl
+++ b/src/information/information_definitions/override_parameters.jl
@@ -22,10 +22,54 @@ const TSALLIS_MULTIVARIATE_MEASURES = Union{
     JointEntropyTsallis,
 }
 
-function estimator_with_overridden_parameters(defintion::CMITsallis, 
-        est::InformationMeasureEstimator{<:Tsallis})
-    modified_est = @set est.base = definition.base
-    modified_est = @set est.q = definition.q
+const RENYI_MULTIVARIATE_MEASURES = Union{
+    CMIRenyiPoczos, CMIRenyiSarbu, CMIRenyiJizba,
+    MIRenyiJizba, MIRenyiSarbu,
+    JointEntropyRenyi,
+}
 
+const SHANNON_MULTIVARIATE_MEASURES = Union{
+    CMIShannon,
+    MIShannon,
+    CEShannon,
+    JointEntropyShannon,
+}
+
+
+function estimator_with_overridden_parameters(
+        definition::TSALLIS_MULTIVARIATE_MEASURES, 
+        est::InformationMeasureEstimator{<:Tsallis}
+    )
+    # The low-level definition
+    lowdef = est.definition
+   
+    # Update the low-level definition. Have to do this step-wise. Ugly, but works.
+    modified_lowdef = @set lowdef.base = definition.base # update `base` field
+    modified_lowdef = @set modified_lowdef.q = definition.q # update `q` field
+
+    # Set the definition for the low-level estimator to the updated definition.
+    modified_est = @set est.definition = modified_lowdef
+    
+    return modified_est
+end
+
+function estimator_with_overridden_parameters(
+        definition::RENYI_MULTIVARIATE_MEASURES, 
+        est::InformationMeasureEstimator{<:Renyi}
+    )
+    lowdef = est.definition
+    modified_lowdef = @set lowdef.base = definition.base # update `base` field
+    modified_lowdef = @set modified_lowdef.q = definition.q # update `q` field
+    modified_est = @set est.definition = modified_lowdef
+    return modified_est
+end
+
+function estimator_with_overridden_parameters(
+        definition::SHANNON_MULTIVARIATE_MEASURES, 
+        est::InformationMeasureEstimator{<:Shannon}
+    )
+    lowdef = est.definition
+    modified_lowdef = @set lowdef.base = definition.base # update `base` field
+    modified_est = @set est.definition = modified_lowdef
     return modified_est
 end

--- a/src/information/information_definitions/override_parameters.jl
+++ b/src/information/information_definitions/override_parameters.jl
@@ -73,3 +73,14 @@ function estimator_with_overridden_parameters(
     modified_est = @set est.definition = modified_lowdef
     return modified_est
 end
+
+
+function estimator_with_overridden_parameters(
+        definition::CMIShannon, 
+        est::MutualInformationEstimator{<:MIShannon}
+    )
+    lowdef = est.definition
+    modified_lowdef = @set lowdef.base = definition.base # update `base` field
+    modified_est = @set est.definition = modified_lowdef
+    return modified_est
+end

--- a/src/information/information_estimators/EntropyDecomposition.jl
+++ b/src/information/information_estimators/EntropyDecomposition.jl
@@ -1,0 +1,53 @@
+
+export EntropyDecomposition
+
+"""
+    EntropyDecomposition(definition::MultivariateInformationMeasure, 
+        est::DifferentialInfoEstimator)
+    EntropyDecomposition(definition::MultivariateInformationMeasure,
+        est::DiscreteInfoEstimator,
+        discretization::OutcomeSpace,
+        pest::ProbabilitiesEstimator = RelativeAmount())
+
+If `est` is a [`DifferentialInfoEstimator`](@ref), then `discretization` and `pest` 
+are ignored. If `est` is a [`DiscreteInfoEstimator`](@ref), then `discretization` and a
+probabilities estimator `pest` must also be provided (default to `RelativeAmount`, 
+which uses naive plug-in probabilities).
+
+## Usage
+
+- [`information`](@ref)`(est::EntropyDecomposition, x...)`.
+
+See also: [`MutualInformationEstimator`](@ref), [`MultivariateInformationMeasure`](@ref).
+"""
+struct EntropyDecomposition{M <: MultivariateInformationMeasure, E <: InformationMeasureEstimator, D, P} <: InformationMeasureEstimator{M}
+    definition::M # extend API from complexity measures: definition must be the first field of the info estimator.
+    est::E # The estimator + measure which `definition` is decomposed into.
+    discretization::D # `Nothing` if `est` is a `DifferentialInfoEstimator`.
+    pest::P # `Nothing` if `est` is a `DifferentialInfoEstimator`.
+
+
+    function EntropyDecomposition(
+        definition::MultivariateInformationMeasure, 
+        est::DifferentialInfoEstimator)
+        M = typeof(definition)
+        E = typeof(est)
+        return new{M, E, Nothing, Nothing}(definition, est, nothing, nothing)
+    end
+
+    function EntropyDecomposition(
+            definition::MultivariateInformationMeasure, 
+            est::DiscreteInfoEstimator, 
+            discretization::D,
+            pest::ProbabilitiesEstimator = RelativeAmount(),
+        ) where {D}
+        M = typeof(definition)
+        E = typeof(est)
+        P = typeof(pest)
+    
+        return new{M, E, D, P}(definition, est, discretization, pest)
+    end
+
+end
+
+

--- a/src/information/information_estimators/MIDecomposition.jl
+++ b/src/information/information_estimators/MIDecomposition.jl
@@ -1,0 +1,20 @@
+
+export MIDecomposition
+
+"""
+    MIDecomposition(definition::MultivariateInformationMeasure, 
+        est::MutualInformationEstimator)
+
+Estimate some multivariate information measure specified by `definition`, by decomposing
+it into a combination of mutual information terms, which are estimated using `est`.
+
+## Usage
+
+- [`information`](@ref)`(est::MIDecomposition, x...)`.
+
+See also: [`MutualInformationEstimator`](@ref), [`MultivariateInformationMeasure`](@ref).
+"""
+struct MIDecomposition{M <: MultivariateInformationMeasure, E} <: InformationMeasureEstimator{M}
+    definition::M # extend API from complexity measures: definition must be the first field of the info estimator.
+    est::E # The MI estimator + measure which `definition` is decomposed into.
+end

--- a/src/information/information_estimators/information_estimators.jl
+++ b/src/information/information_estimators/information_estimators.jl
@@ -1,5 +1,9 @@
 include("Contingency.jl")
 include("DiscreteDecomposition.jl")
 include("DifferentialDecomposition.jl")
+
 include("EntropyDecomposition.jl")
+include("MIDecomposition.jl")
+
 abstract type MutualInformationEstimator{M} <: BivariateInformationMeasureEstimator end
+abstract type ConditionalMutualInformationEstimator{M} <: MultivariateInformationMeasureEstimator end

--- a/src/information/information_estimators/information_estimators.jl
+++ b/src/information/information_estimators/information_estimators.jl
@@ -1,3 +1,5 @@
 include("Contingency.jl")
 include("DiscreteDecomposition.jl")
 include("DifferentialDecomposition.jl")
+include("EntropyDecomposition.jl")
+abstract type MutualInformationEstimator{M} <: BivariateInformationMeasureEstimator end

--- a/src/information/information_estimators/mutual_info_estimators/KSG1.jl
+++ b/src/information/information_estimators/mutual_info_estimators/KSG1.jl
@@ -1,0 +1,93 @@
+using Neighborhood: Chebyshev, KDTree, NeighborNumber, Theiler
+using Neighborhood: bulksearch, inrangecount
+using SpecialFunctions: digamma
+using DelayEmbeddings: AbstractStateSpaceSet, StateSpaceSet
+using DelayEmbeddings: dimension
+using Statistics: mean
+export KraskovStögbauerGrassberger1, KSG1
+
+"""
+    KSG1 <: MutualInformationEstimator
+    KraskovStögbauerGrassberger1 <: MutualInformationEstimator
+    KraskovStögbauerGrassberger1(; k::Int = 1, w = 0, metric_marginals = Chebyshev())
+
+The `KraskovStögbauerGrassberger1` mutual information estimator (you can use `KSG1` for
+short) is the ``I^{(1)}`` `k`-th nearest neighbor estimator from [Kraskov2004](@citet).
+
+## Keyword arguments
+
+- **`k::Int`**: The number of nearest neighbors to consider. Only information about the
+    `k`-th nearest neighbor is actually used.
+- **`metric_marginals`**: The distance metric for the marginals for the marginals can be
+    any metric from `Distances.jl`. It defaults to `metric_marginals = Chebyshev()`, which
+    is the same as in Kraskov et al. (2004).
+- **`w::Int`**: The Theiler window, which determines if temporal neighbors are excluded
+    during neighbor searches in the joint space. Defaults to `0`, meaning that only the
+    point itself is excluded.
+
+## Description
+
+Let the joint StateSpaceSet ``X := \\{\\bf{X}_1, \\bf{X_2}, \\ldots, \\bf{X}_m \\}`` be defined by the
+concatenation of the marginal StateSpaceSets ``\\{ \\bf{X}_k \\}_{k=1}^m``, where each ``\\bf{X}_k``
+is potentially multivariate. Let ``\\bf{x}_1, \\bf{x}_2, \\ldots, \\bf{x}_N`` be the points
+in the joint space ``X``.
+"""
+struct KraskovStögbauerGrassberger1{M, MJ, MM} <: MutualInformationEstimator{M}
+    definition::M # the definition of the measure
+    k::Int
+    w::Int
+    metric_joint::MJ # always Chebyshev, otherwise estimator is not valid!
+    metric_marginals::MM
+
+    function KraskovStögbauerGrassberger1(;
+            definition = MIShannon(),
+            k::Int = 1,
+            w::Int = 0,
+            metric_marginals::MM = Chebyshev()) where MM
+        metric_joint = Chebyshev()
+        M = typeof(definition)
+        TJ = typeof(metric_joint)
+        new{M, TJ, MM}(definition, k, w, metric_joint, metric_marginals)
+    end
+end
+const KSG1 = KraskovStögbauerGrassberger1
+
+function information(est::KSG1{<:MIShannon}, x::VectorOrStateSpaceSet...)
+    verify_number_of_inputs_vars(est.definition, length(x))
+
+
+    (; definition, k, w, metric_joint, metric_marginals) = est
+    joint = StateSpaceSet(x...)
+    marginals = map(xᵢ -> StateSpaceSet(xᵢ), x)
+    M = length(x)
+    N = length(joint)
+
+    # `ds[i]` := the distance to k-th nearest neighbor for the point `joint[i]`.
+    # In the paper, for method 1, ϵᵢ = 2*ds[i].
+    tree_joint = KDTree(joint, metric_joint)
+    ds = last.(bulksearch(tree_joint, joint, NeighborNumber(k), Theiler(w))[2])
+
+    # `marginals_nₖs[i][k]` contains the number of points within radius `ds[i]` of
+    # the point `marginals[k][i]`.
+    ns = [zeros(Int, N) for m in eachindex(marginals)]
+    s = 0.0
+    for (m, xₘ) in enumerate(marginals)
+        marginal_inrangecount!(est, ns[m], xₘ, ds)
+    end
+    marginal_nₖs = StateSpaceSet(ns...)
+    mi = digamma(k) +
+        (M - 1) * digamma(N) -
+        mean(sum(digamma.(nₖ)) for nₖ in marginal_nₖs)
+    return convert_logunit(mi, ℯ, definition.base)
+end
+
+function marginal_inrangecount!(est::KraskovStögbauerGrassberger1, ns, xₘ, ds)
+    @assert length(ns) == length(xₘ)
+    tree = KDTree(xₘ, est.metric_marginals)
+    @inbounds for i in eachindex(xₘ)
+        # Usually, we'd subtract 1 because inrangecount includes the point itself, but
+        # we do the +1 in ψ(n + 1) here, so we don't need the +1 in the final MI formula.
+        ns[i] = inrangecount(tree, xₘ[i], ds[i])
+    end
+    return ns
+end

--- a/src/information/information_estimators/mutual_info_estimators/mutual_info_estimators.jl
+++ b/src/information/information_estimators/mutual_info_estimators/mutual_info_estimators.jl
@@ -1,0 +1,2 @@
+
+include("KSG1.jl")

--- a/src/information/information_measures.jl
+++ b/src/information/information_measures.jl
@@ -1,6 +1,8 @@
 export MultivariateInformationMeasure
 export MultivariateInformationMeasureEstimator
 export BivariateInformationMeasure
+export BivariateInformationMeasureEstimator
+
 """
     MultivariateInformationMeasure <: AssociationMeasure
 
@@ -36,7 +38,8 @@ The supertype for all bivariate information-based measure definitions.
 """
 abstract type BivariateInformationMeasure <: MultivariateInformationMeasure end
 
-min_inputs_vars(::BivariateInformationMeasure) = 3
-max_inputs_vars(::BivariateInformationMeasure) = 3
+min_inputs_vars(::BivariateInformationMeasure) = 2
+max_inputs_vars(::BivariateInformationMeasure) = 2
 
 abstract type MultivariateInformationMeasureEstimator end
+abstract type BivariateInformationMeasureEstimator end

--- a/test/information/information.jl
+++ b/test/information/information.jl
@@ -6,3 +6,5 @@ include("conditional_mutual_informations/conditional_mutual_informations.jl")
 
 # Estimators of the information measures.
 include("estimators/discrete/joint.jl")
+
+include("internal_api.jl")

--- a/test/information/internal_api.jl
+++ b/test/information/internal_api.jl
@@ -1,0 +1,19 @@
+using Test 
+using CausalityTools
+
+# ----------------------------------------------------------------
+# This file tests internal functions.
+# ----------------------------------------------------------------
+def_renyi = CMIRenyiSarbu(; q = 5, base = 5)
+def_tsallis = CMITsallis(; q = 5, base = 5)
+def_shannon = CMIShannon(; base = 5)
+est_renyi = PlugIn(Renyi(; q = 0.5, base = 2))
+est_tsallis = PlugIn(Tsallis(; q = 0.5, base = 2))
+est_shannon = PlugIn(Shannon(; base = 2))
+
+new_est_renyi = CausalityTools.estimator_with_overridden_parameters(def_renyi, est_renyi)
+new_est_tsallis = CausalityTools.estimator_with_overridden_parameters(def_tsallis, est_tsallis)
+new_est_shannon = CausalityTools.estimator_with_overridden_parameters(def_shannon, est_shannon)
+@test new_est_renyi == PlugIn(Renyi(; q = 5, base = 5)) 
+@test new_est_tsallis == PlugIn(Tsallis(; q = 5, base = 5)) 
+@test new_est_shannon == PlugIn(Shannon(; base = 5)) 


### PR DESCRIPTION
Part of working on the new API. This PR is just to avoid a mess with too many changes at the same time. No need for review here until everything is put together in the `new_probs_api` branch later. 