### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/utils/groupslices.jl
+++ b/src/utils/groupslices.jl
@@ -43,7 +43,7 @@ export groupslices, groupinds, firstinds, lastinds
 struct Prehashed
     hash::UInt
 end
-hash(x::Prehashed) = x.hash
+hash(x::Prehashed, h::UInt) = hash(x.hash, h)
 
 """
     groupslices(V::AbstractVector)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.