### PR TITLE
Fix CI: Pin CausalInference (mschauer/CausalInference.jl#176)

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 
 [compat]
-CausalInference = "=0.19.1" # pin to 19.1 bc current (0.19.2, 2025-11-24, 8e1e6d9) fails precompile
+CausalInference = "0.19.3" # v0.19.2 fails precompile
 ComplexityMeasures = "^3.8"
 DynamicalSystemsBase = "3"
 julia = "^1.10.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,6 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 
 [compat]
+CausalInference = "=0.19.1" # pin to 19.1 bc current (0.19.2, 2025-11-24, 8e1e6d9) fails precompile
 ComplexityMeasures = "^3.8"
 DynamicalSystemsBase = "3"
 julia = "^1.10.10"


### PR DESCRIPTION
The CI fails right now because CausalInference v0.19.2 fails to precompile (mschauer/CausalInference.jl#176).
~This PR fixes it to the last running precompile I found (v0.19.1).~