### PR TITLE
Pin ComplexityMeasures.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 [compat]
 Accessors = "^0.1.28"
 Combinatorics = "1"
-ComplexityMeasures = "3.8"
+ComplexityMeasures = "< 3.10"
 DSP = "^0.7, 0.8"
 DelayEmbeddings = "2.9"
 Distances = "^0.10"


### PR DESCRIPTION
ComplexityMeasures.jl v3.10 converted `TransferOperator <: OutcomeSpace` to `TransferOperator <: ProbabilitiesEstimator`.As a consequence, e.g. transfer entropy estimation in this package is broken until a fix is in place. This PR simply pins ComplexityMeasures.jl to a version before this change was made.