### PR TITLE
Minor release allowing ComplexityMeasures v3.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 [compat]
 Accessors = "^0.1.28"
 Combinatorics = "1"
-ComplexityMeasures = "3.8 - 3.9"
+ComplexityMeasures = "3.10"
 DSP = "^0.7, 0.8"
 DelayEmbeddings = "2.9"
 Distances = "^0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Associations"
 uuid = "614afb3a-e278-4863-8805-9959372b9ec2"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "Tor Einar Møller <temolle@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/kahaaga/Associations.jl.git"
-version = "4.6.0"
+version = "4.7.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Associations = "614afb3a-e278-4863-8805-9959372b9ec2"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"
@@ -25,6 +26,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 
 [compat]
-ComplexityMeasures = "^3.8"
+ComplexityMeasures = "3.10"
 DynamicalSystemsBase = "3"
 julia = "^1.10.10"

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,4 +1,3 @@
-
 @article{Sun2015,
     author = {Sun, Jie and Taylor, Dane and Bollt, Erik M.},
     title = {Causal Network Inference by Optimal Causation Entropy},
@@ -1015,6 +1014,20 @@ abstract = {Mutual information (MI) is a basic concept in information theory. Th
   url = {https://pubs.aip.org/aip/cha/article/28/3/033114/685022},
 }
 
+@article{LeonenkoProzantoSavani2008,
+  author = {Nikolai Leonenko and Luc Pronzato and Vippal Savani},
+  title = {A class of Rényi information estimators for multidimensional densities},
+  volume = {36},
+  journal = {The Annals of Statistics},
+  number = {5},
+  publisher = {Institute of Mathematical Statistics},
+  pages = {2153 -- 2182},
+  abstract = {A class of estimators of the Rényi and Tsallis entropies of an unknown distribution f in ℝm is presented. These estimators are based on the kth nearest-neighbor distances computed from a sample of N i.i.d. vectors with distribution f. We show that entropies of any order q, including Shannon’s entropy, can be estimated consistently with minimal assumptions on f. Moreover, we show that it is straightforward to extend the nearest-neighbor method to estimate the statistical distance between two distributions using one i.i.d. sample from each.},
+  keywords = {Entropy estimation, estimation of divergence, estimation of statistical distance, Havrda–Charvát entropy, nearest-neighbor distances, Rényi entropy, Tsallis entropy},
+  year = {2008},
+  doi = {10.1214/07-AOS539},
+  url = {https://doi.org/10.1214/07-AOS539}
+}
 
 @article{Vasicek1976,
   title={A test for normality based on sample entropy},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1030,22 +1030,6 @@ abstract = {Mutual information (MI) is a basic concept in information theory. Th
 }
 
 
-@article{LeonenkoProzantoSavani2008,
-  author = {Nikolai Leonenko and Luc Pronzato and Vippal Savani},
-  title = {A class of Rényi information estimators for multidimensional densities},
-  volume = {36},
-  journal = {The Annals of Statistics},
-  number = {5},
-  publisher = {Institute of Mathematical Statistics},
-  pages = {2153 -- 2182},
-  abstract = {A class of estimators of the Rényi and Tsallis entropies of an unknown distribution f in ℝm is presented. These estimators are based on the kth nearest-neighbor distances computed from a sample of N i.i.d. vectors with distribution f. We show that entropies of any order q, including Shannon’s entropy, can be estimated consistently with minimal assumptions on f. Moreover, we show that it is straightforward to extend the nearest-neighbor method to estimate the statistical distance between two distributions using one i.i.d. sample from each.},
-  keywords = {Entropy estimation, estimation of divergence, estimation of statistical distance, Havrda–Charvát entropy, nearest-neighbor distances, Rényi entropy, Tsallis entropy},
-  year = {2008},
-  doi = {10.1214/07-AOS539},
-  url = {https://doi.org/10.1214/07-AOS539}
-}
-
-
 @article{Vasicek1976,
   title={A test for normality based on sample entropy},
   author={Vasicek, Oldrich},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -696,20 +696,6 @@ abstract = {Mutual information (MI) is a basic concept in information theory. Th
   url = {https://link.aps.org/doi/10.1103/PhysRevE.95.052206}
 }
 
-@article{LeonenkoProzantoSavani2008,
-  author = {Nikolai Leonenko and Luc Pronzato and Vippal Savani},
-  title = {{A class of Rényi information estimators for multidimensional densities}},
-  volume = {36},
-  journal = {The Annals of Statistics},
-  number = {5},
-  publisher = {Institute of Mathematical Statistics},
-  pages = {2153 -- 2182},
-  abstract = {A class of estimators of the Rényi and Tsallis entropies of an unknown distribution f in ℝm is presented. These estimators are based on the kth nearest-neighbor distances computed from a sample of N i.i.d. vectors with distribution f. We show that entropies of any order q, including Shannon’s entropy, can be estimated consistently with minimal assumptions on f. Moreover, we show that it is straightforward to extend the nearest-neighbor method to estimate the statistical distance between two distributions using one i.i.d. sample from each.},
-  keywords = {Entropy estimation, estimation of divergence, estimation of statistical distance, Havrda–Charvát entropy, nearest-neighbor distances, Rényi entropy, Tsallis entropy},
-  year = {2008},
-  doi = {10.1214/07-AOS539},
-  URL = {https://doi.org/10.1214/07-AOS539}
-}
 
 @article{Frenzel2007,
   title = {Partial Mutual Information for Coupling Analysis of Multivariate Time Series},
@@ -1262,17 +1248,6 @@ URL = {https://doi.org/10.1214/14-AOS1255}
   year={2009},
   publisher={Springer},
   url={https://link.springer.com/book/10.1007/978-0-387-85359-8}
-}
-
-@article{Arnhold1999,
-  title={A robust method for detecting interdependences: application to intracranially recorded EEG},
-  author={Arnhold, Jochen and Grassberger, Peter and Lehnertz, Klaus and Elger, Christian Erich},
-  journal={Physica D: Nonlinear Phenomena},
-  volume={134},
-  number={4},
-  pages={419--430},
-  year={1999},
-  publisher={Elsevier}
 }
 
 @article{Chatterjee2021,

--- a/docs/src/examples/examples_associations.md
+++ b/docs/src/examples/examples_associations.md
@@ -1250,7 +1250,7 @@ sys = system(Logistic4Chain(; rng))
 x, y, z, w = columns(first(trajectory(sys, 300, Ttr = 10000)))
 
 precise = true # precise bin edges
-discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
+discretization = CodifyVariables(ValueBinning(RectangularBinning(2, precise))) #
 est_disc_to = EntropyDecomposition(TEShannon(), PlugIn(Shannon()), discretization);
 association(est_disc_to, x, y), association(est_disc_to, y, x)
 ```
@@ -1502,7 +1502,7 @@ sys = system(Logistic4Chain(; rng))
 x, y, z, w = columns(first(trajectory(sys, 300, Ttr = 10000)))
 
 precise = true # precise bin edges
-discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
+discretization = CodifyVariables(ValueBinning(RectangularBinning(2, precise))) #
 est_disc_to = EntropyDecomposition(TERenyiJizba(), PlugIn(Renyi()), discretization);
 association(est_disc_to, x, y), association(est_disc_to, y, x)
 ```

--- a/docs/src/examples/examples_infer_graphs.md
+++ b/docs/src/examples/examples_infer_graphs.md
@@ -169,7 +169,7 @@ pairwise_test = SurrogateAssociationTest(est_pairwise; rng, nshuffles = 50)
 cond_test = LocalPermutationTest(est_cond; rng, nshuffles = 50)
 alg = PC(pairwise_test, cond_test; α = 0.05)
 est_cpdag_nonparametric = infer_graph(alg, X; verbose = false)
-plotgraph(est_cpdag_nonparametric)
+plotgraph(est_cpdag_nonparametric; nlabels = ["x", "v", "w", "z", "s"])
 ```
 
 We get the same basic structure of the graph, but which directional associations 

--- a/src/methods/information/counts_and_probs/encoding/codify_variables.jl
+++ b/src/methods/information/counts_and_probs/encoding/codify_variables.jl
@@ -71,6 +71,20 @@ function CodifyVariables(o::OutcomeSpace)
     return CodifyVariables((o,))
 end
 
+function CodifyVariables(os::NTuple{N}) where N
+    x = collect(os)
+    if any(isa.(x, TransferOperator))
+        s = "CodifyVariables does not support `ComplexityMeasures.TransferOperator`. " *
+            "Its type has changed from `TransferOperator <: OutcomeSpace` to " *
+            "`TransferOperator <: ProbabilitiesEstimator`. To use the old behaviour, please" *
+            " install/pin Associations v4.6."
+        throw(ArgumentError(s))
+    elseif any(isa.(x, ProbabilitiesEstimator))
+        s = "CodifyVariables does not support `ProbabilitiesEstimator`s. Use a `CountBasedOutcomeSpace` instead."
+    end
+    throw(ArgumentError(s))
+end
+
 """
     codify(d::CodifyVariables, x::Vararg{<:AbstractStateSpaceSet, N})
     codify(d::CodifyPoints, x::Vararg{<:AbstractStateSpaceSet, N})

--- a/test/methods/information/core/probabilities.jl
+++ b/test/methods/information/core/probabilities.jl
@@ -41,3 +41,9 @@ oy = OrdinalPatterns(m = 3)
 # Now estimate mutual information
 discretization = CodifyVariables((ox, oy))
 @test probabilities(discretization, x, y) isa Probabilities{T, 2} where T
+
+
+# Temporary test while the TransferOperator <: ProbabilitiesEstimator issue is 
+# resolved (ref https://github.com/JuliaDynamics/Associations.jl/issues/409).
+@test_throws ArgumentError("CodifyVariables does not support `ComplexityMeasures.TransferOperator`. Its type has changed from `TransferOperator <: OutcomeSpace` to `TransferOperator <: ProbabilitiesEstimator`. To use the old behaviour, please install/pin Associations v4.6.") CodifyVariables(TransferOperator(RectangularBinning(2, true)))
+@test_throws ArgumentError("CodifyVariables does not support `ProbabilitiesEstimator`s. Use a `CountBasedOutcomeSpace` instead.") CodifyVariables(RelativeAmount())

--- a/test/methods/information/transfer_entropies/te_renyi_jizba.jl
+++ b/test/methods/information/transfer_entropies/te_renyi_jizba.jl
@@ -17,30 +17,31 @@ est_disc = EntropyDecomposition(def, PlugIn(Renyi()), CodifyVariables(ValueBinni
 @test association(est_disc, x, z) isa Real
 @test association(est_disc, x, z, y) isa Real
 
+# TODO: update when https://github.com/JuliaDynamics/Associations.jl/issues/409 is resolved.
 # Test `TransferOperator` decomposition explicitly, because it has a special implementation
-precise = true # precise bin edge
-discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
-est_disc = EntropyDecomposition(TERenyiJizba(), PlugIn(Renyi()), discretization);
-@test association(est_disc, x, z) isa Real
-@test association(est_disc, x, z, y) isa Real
+#precise = true # precise bin edge
+#discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
+#est_disc = EntropyDecomposition(TERenyiJizba(), PlugIn(Renyi()), discretization);
+#@test association(est_disc, x, z) isa Real
+#@test association(est_disc, x, z, y) isa Real
 
 # Check that in the limit of a lot of points, we roughly get the same answer for transfer 
 # operator and regular value binning. 
-sys = system(Logistic4Chain(; rng))
-x, y, z, w = columns(first(trajectory(sys, 10000, Ttr=10000)))
+#sys = system(Logistic4Chain(; rng))
+#x, y, z, w = columns(first(trajectory(sys, 10000, Ttr=10000)))
 
-te_def = TERenyiJizba(base=3, q=0.5)
-def_renyi = Renyi()
+#te_def = TERenyiJizba(base=3, q=0.5)
+#def_renyi = Renyi()
 
-disc_vf = CodifyVariables(ValueBinning(2))
-disc_to = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
+#disc_vf = CodifyVariables(ValueBinning(2))
+#disc_to = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
 
-est_disc_vf = EntropyDecomposition(te_def, PlugIn(def_renyi), disc_vf);
-est_disc_to = EntropyDecomposition(te_def, PlugIn(def_renyi), disc_to);
-te_vf = association(est_disc_vf, x, z)
-te_to = association(est_disc_to, x, z)
+#est_disc_vf = EntropyDecomposition(te_def, PlugIn(def_renyi), disc_vf);
+#est_disc_to = EntropyDecomposition(te_def, PlugIn(def_renyi), disc_to);
+#te_vf = association(est_disc_vf, x, z)
+#te_to = association(est_disc_to, x, z)
 # See that values are within 1% of each other
-@test in_agreement(te_vf, te_to; agreement_threshold=0.01)
+#@test in_agreement(te_vf, te_to; agreement_threshold=0.01)
 
 # ---------------
 # Pretty printing

--- a/test/methods/information/transfer_entropies/te_shannon.jl
+++ b/test/methods/information/transfer_entropies/te_shannon.jl
@@ -36,13 +36,13 @@ est_lindner = Lindner(def, k = 3)
 @test association(est_lindner, x, z) isa Real
 @test association(est_lindner, x, z, y) isa Real
 
-
+# TODO: update when https://github.com/JuliaDynamics/Associations.jl/issues/409 is resolved.
 # Test `TransferOperator` decomposition explicitly, because it has a special implementation
-precise = true # precise bin edge
-discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
-est_disc = EntropyDecomposition(TEShannon(), PlugIn(Shannon()), discretization);
-@test association(est_disc, x, z) isa Real
-@test association(est_disc, x, z, y) isa Real
+#precise = true # precise bin edge
+#discretization = CodifyVariables(TransferOperator(RectangularBinning(2, precise))) #
+#est_disc = EntropyDecomposition(TEShannon(), PlugIn(Shannon()), discretization);
+#@test association(est_disc, x, z) isa Real
+#@test association(est_disc, x, z, y) isa Real
 
 # `JointProbabilities`
 x, y, z = rand(rng, 30), rand(rng, 30), rand(rng, 30)


### PR DESCRIPTION
## What's new

- Throw errors when using `ProbabilitiesEstimator`s with `CodifyVariables`, in particular with `TransferOperator` (ref #409). Test that these throw.
- Pending a fix to that issue, 
    - disable tests for transfer entropy using `TransferOperator` 
    - use `ValueBinning` instead of `TransferOperator` in doc examples. 
- Fix docs build
    - Remove duplicate BiBTex entries
- Minor fix to graph inference docs 
    - Added missing labels to plot
- Up minor version to 4.7 

Once #409 is fixed, the doc examples and tests should be enabled again. Until that is resolved, dev can continue while users experiencing errors with the `TransferOperator` get proper direction to resolve the problem.