### PR TITLE
docs: clarify CorrTest partial correlation documentation

### DIFF
--- a/src/independence_tests/parametric/CorrTest.jl
+++ b/src/independence_tests/parametric/CorrTest.jl
@@ -13,7 +13,7 @@ import HypothesisTests: pvalue
     CorrTest()
 
 An independence test based correlation (for two variables) and partial
-correlation (for three variables) [Levy1978](@cite); as described in
+correlation (for three or more variables) [Levy1978](@cite); as described in
 [Schmidt2018](@citet).
 
 Uses [`PearsonCorrelation`](@ref) and [`PartialCorrelation`](@ref) internally.


### PR DESCRIPTION
## Summary

This PR updates the `CorrTest` documentation to clarify that partial correlation applies to **three or more variables**, rather than only **three variables**.

closes  #414